### PR TITLE
manifests for the jenkins rpmbuilder slaves

### DIFF
--- a/modules/maven/Gemfile
+++ b/modules/maven/Gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+group :rake do
+  gem 'puppet', '>=2.7.20'
+  gem 'rspec-puppet', '>=0.1.3'
+  gem 'rake',         '>=0.9.2.2'
+  gem 'puppet-lint',  '>=0.1.12'
+  gem 'puppetlabs_spec_helper'
+  gem 'puppet-blacksmith', '>=1.0.5'
+  gem 'librarian-puppet-maestrodev', '>=0.9.8'
+  gem 'rspec-system-puppet'
+  gem 'rspec-system-serverspec'
+end

--- a/modules/maven/Gemfile.lock
+++ b/modules/maven/Gemfile.lock
@@ -1,0 +1,92 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    builder (3.2.2)
+    diff-lcs (1.2.4)
+    facter (1.7.2)
+    hiera (1.2.1)
+      json_pure
+    highline (1.6.19)
+    json (1.8.0)
+    json_pure (1.8.0)
+    kwalify (0.7.2)
+    librarian (0.1.1)
+      highline
+      thor (~> 0.15)
+    librarian-puppet-maestrodev (0.9.9.8)
+      json
+      librarian (>= 0.1.1)
+    metaclass (0.0.1)
+    mime-types (1.25)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    net-scp (1.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (2.7.0)
+    nokogiri (1.5.9)
+    puppet (3.2.4)
+      facter (~> 1.6)
+      hiera (~> 1.0)
+      rgen (~> 0.6.5)
+    puppet-blacksmith (2.0.2)
+      nokogiri
+      puppet (>= 2.7.16)
+      rest-client
+    puppet-lint (0.3.2)
+    puppetlabs_spec_helper (0.4.1)
+      mocha (>= 0.10.5)
+      rake
+      rspec (>= 2.9.0)
+      rspec-puppet (>= 0.1.1)
+    rake (10.1.0)
+    rbvmomi (1.6.0)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    rgen (0.6.6)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.5)
+    rspec-expectations (2.14.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.3)
+    rspec-puppet (0.1.6)
+      rspec
+    rspec-system (2.3.0)
+      kwalify (~> 0.7.2)
+      net-scp (~> 1.1)
+      net-ssh (~> 2.6)
+      nokogiri (~> 1.5.9)
+      rbvmomi (~> 1.6)
+      rspec (~> 2.13)
+      systemu (~> 2.5)
+    rspec-system-puppet (2.2.0)
+      rspec-system (~> 2.0)
+    rspec-system-serverspec (1.0.0)
+      rspec-system (~> 2.0)
+      serverspec (~> 0.6.0)
+    serverspec (0.6.3)
+      highline
+      net-ssh
+      rspec (~> 2.0)
+    systemu (2.5.2)
+    thor (0.18.1)
+    trollop (2.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  librarian-puppet-maestrodev (>= 0.9.8)
+  puppet (>= 2.7.20)
+  puppet-blacksmith (>= 1.0.5)
+  puppet-lint (>= 0.1.12)
+  puppetlabs_spec_helper
+  rake (>= 0.9.2.2)
+  rspec-puppet (>= 0.1.3)
+  rspec-system-puppet
+  rspec-system-serverspec

--- a/modules/maven/LICENSE
+++ b/modules/maven/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/modules/maven/Modulefile
+++ b/modules/maven/Modulefile
@@ -1,0 +1,10 @@
+name 'maestrodev-maven'
+version '1.1.7'
+
+author 'maestrodev'
+license 'Apache License, Version 2.0'
+project_page 'http://github.com/maestrodev/puppet-maven'
+source 'http://github.com/maestrodev/puppet-maven'
+summary 'Apache Maven module for Puppet'
+description 'A Puppet module to download artifacts from Maven repositories'
+dependency 'maestrodev/wget', '>=1.0.0'

--- a/modules/maven/Puppetfile
+++ b/modules/maven/Puppetfile
@@ -1,0 +1,3 @@
+forge 'http://forge.puppetlabs.com'
+
+mod 'maestrodev/wget',     '>=1.0.0'

--- a/modules/maven/Puppetfile.lock
+++ b/modules/maven/Puppetfile.lock
@@ -1,0 +1,8 @@
+FORGE
+  remote: http://forge.puppetlabs.com
+  specs:
+    maestrodev/wget (1.1.0)
+
+DEPENDENCIES
+  maestrodev/wget (>= 1.0.0)
+

--- a/modules/maven/README.md
+++ b/modules/maven/README.md
@@ -1,0 +1,188 @@
+Puppet-Maven
+============
+
+A Puppet recipe for Apache Maven, to download artifacts from a Maven repository
+
+Uses [Apache Maven](http://maven.apache.org) command line to download the artifacts.
+
+Building and Installing the Module
+----------------------------------
+
+To build the module for installing in your Puppet master:
+
+```sh
+gem install puppet-module
+git clone git://github.com/maestrodev/puppet-maven.git
+cd puppet-maven
+puppet module build
+puppet module install pkg/maestrodev-maven-1.0.1.tar.gz
+```
+
+Of course, you can also clone the repository straight into `/etc/puppet/modules/maven` as well.
+
+Developing and Testing the Module
+---------------------------------
+
+If you are developing the module, it can be built using `rake`:
+
+```sh
+gem install bundler
+bundle
+rake spec
+rake spec:system
+```
+
+Usage
+-----
+
+```puppet
+  maven { "/tmp/myfile":
+    id => "groupId:artifactId:version:packaging:classifier",
+    repos => ["id::layout::http://repo.acme.com","http://repo2.acme.com"],
+  }
+```
+
+or
+
+```puppet
+  maven { "/tmp/myfile":
+    groupid => "org.apache.maven",
+    artifactid => "maven-core",
+    version => "3.0.5",
+    packaging => "jar",
+    classifier => "sources",
+    repos => ["id::layout::http://repo.acme.com","http://repo2.acme.com"],
+  }
+```
+
+### ensure
+
+`ensure` may be one of two values:
+* `present` (the default) -- the specified maven artifact is downloaded when no file exists
+   at `path` (or `name` if no path is specified.)  This is probably makes
+   sense when the specified maven artifact refers to a released (non-SNAPSHOT)
+   artifact.
+*  `latest` -- if value of version is `RELEASE`, `LATEST`, or a SNAPSHOT the repository
+   is queried for an updated artifact.  If an updated artifact is found the file
+   at `path` is replaced.
+
+### MAVEN_OPTS Precedence
+
+Values set in `maven_opts` will be _prepended_ to any existing
+`MAVEN_OPTS` value. This ensures that those already specified will win over
+those added in `mavenrc`.
+
+If you would prefer these options to win, instead use:
+
+```puppet
+  maven_opts        => "",
+  mavenrc_additions => 'MAVEN_OPTS="$MAVEN_OPTS -Xmx1024m"
+```
+
+Examples
+--------
+
+### Setup
+
+```puppet
+  $central = {
+    id => "myrepo",
+    username => "myuser",
+    password => "mypassword",
+    url => "http://repo.acme.com",
+    mirrorof => "external:*",      # if you want to use the repo as a mirror, see maven::settings below
+  }
+  
+  $proxy = {
+    active => true, #Defaults to true
+    protocol => 'http', #Defaults to 'http'
+    host => 'http://proxy.acme.com',
+    username => 'myuser', #Optional if proxy does not require
+    password => 'mypassword', #Optional if proxy does not require
+    nonProxyHosts => 'www.acme.com', #Optional, provides exceptions to the proxy
+  }
+
+  # Install Maven
+  class { "maven::maven":
+    version => "3.0.5", # version to install
+    # you can get Maven tarball from a Maven repository instead than from Apache servers, optionally with a user/password
+    repo => {
+      #url => "http://repo.maven.apache.org/maven2",
+      #username => "",
+      #password => "",
+    }
+  } ->
+
+  # Setup a .mavenrc file for the specified user
+  maven::environment { 'maven-env' : 
+      user => 'root',
+      # anything to add to MAVEN_OPTS in ~/.mavenrc
+      maven_opts => '-Xmx1384m',       # anything to add to MAVEN_OPTS in ~/.mavenrc
+      maven_path_additions => "",      # anything to add to the PATH in ~/.mavenrc
+
+  } ->
+
+  # Create a settings.xml with the repo credentials
+  maven::settings { 'maven-user-settings' :
+    mirrors => [$central], # mirrors entry in settings.xml, uses id, url, mirrorof from the hash passed
+    servers => [$central], # servers entry in settings.xml, uses id, username, password from the hash passed
+    proxies => [$proxy], # proxies entry in settings.xml, active, protocol, host, username, password, nonProxyHosts
+    user    => 'maven',
+  }
+
+  # defaults for all maven{} declarations
+  Maven {
+    user  => "maven", # you can make puppet run Maven as a specific user instead of root, useful to share Maven settings and local repository
+    group => "maven", # you can make puppet run Maven as a specific group
+    repos => "http://repo.maven.apache.org/maven2"
+  }
+```
+
+Downloading artifacts
+---------------------
+
+```puppet
+  maven { "/tmp/maven-core-3.0.5.jar":
+    id => "org.apache.maven:maven-core:3.0.5:jar",
+    repos => ["central::default::http://repo.maven.apache.org/maven2","http://mirrors.ibiblio.org/pub/mirrors/maven2"],
+  }
+
+  maven { "/tmp/maven-core-3.0.5-sources.jar":
+    groupid    => "org.apache.maven",
+    artifactid => "maven-core",
+    version    => "3.0.5",
+    classifier => "sources",
+  }
+```
+
+Buildr version
+--------------
+
+Initially there was an [Apache Buildr](http://buildr.apache.org) version, but it required to have Buildr installed before running Puppet and you would need to [enable pluginsync](http://docs.puppetlabs.com/guides/plugins_in_modules.html#enabling-pluginsync)
+in both master and clients.
+
+License
+-------
+```
+  Copyright 2011-2012 MaestroDev
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+```
+
+Author
+------
+
+Carlos Sanchez <csanchez@maestrodev.com>
+[MaestroDev](http://www.maestrodev.com)
+2010-03-01
+

--- a/modules/maven/Rakefile
+++ b/modules/maven/Rakefile
@@ -1,0 +1,38 @@
+require 'bundler'
+Bundler.require(:rake)
+require 'rake/clean'
+
+CLEAN.include('spec/fixtures/', 'doc', 'pkg')
+CLOBBER.include('.tmp', '.librarian')
+
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet_blacksmith/rake_tasks'
+require 'rspec-system/rake_task'
+
+PuppetLint.configuration.send("disable_80chars")
+
+# use librarian-puppet to manage fixtures instead of .fixtures.yml
+# offers more possibilities like explicit version management, forge
+# downloads,...
+task :librarian_spec_prep do
+ sh "librarian-puppet install --path=spec/fixtures/modules/"
+end
+task :spec_prep => :librarian_spec_prep
+
+desc "Integration test with Vagrant"
+task :integration do
+  # sh %{vagrant destroy --force}
+  failed = []
+  ["centos64", "centos63"].each do |vm|
+    sh %{vagrant up #{vm}} do |ok|
+      if ok
+        # sh %{vagrant destroy --force #{vm}}
+      else
+        failed << vm
+      end
+    end
+  end
+  fail("Machines failed to start: #{failed.join(', ')}") unless failed.empty?
+end
+
+task :default => [:clean, :spec]

--- a/modules/maven/Vagrantfile
+++ b/modules/maven/Vagrantfile
@@ -1,0 +1,28 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "CentOS-6.4-x86_64-minimal"
+
+  config.vm.synced_folder ".", "/etc/puppet/modules/maven"
+  config.vm.synced_folder "spec/fixtures/modules/wget", "/etc/puppet/modules/wget"
+  config.vm.synced_folder "lib/facter", "/var/lib/puppet/lib/facter"
+
+  # install the java module
+  config.vm.provision :shell, :inline => "test -d /etc/puppet/modules/java || puppet module install puppetlabs/java -v 1.0.1"
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "tests"
+    puppet.manifest_file  = "init.pp"
+  end
+
+  config.vm.define :centos63 do |config|
+    config.vm.box = "CentOS-6.3-x86_64-minimal"
+    config.vm.box_url = "https://repo.maestrodev.com/archiva/repository/public-releases/com/maestrodev/vagrant/CentOS/6.3/CentOS-6.3-x86_64-minimal.box"
+  end
+
+  config.vm.define :centos64 do |config|
+    config.vm.box = "CentOS-6.4-x86_64-minimal"
+    config.vm.box_url = "https://repo.maestrodev.com/archiva/repository/public-releases/com/maestrodev/vagrant/CentOS/6.4/CentOS-6.4-x86_64-minimal.box"
+  end
+end

--- a/modules/maven/lib/facter/maven_version.rb
+++ b/modules/maven/lib/facter/maven_version.rb
@@ -1,0 +1,6 @@
+Facter.add("maven_version") do
+  setcode do
+    version = Facter::Util::Resolution.exec('mvn --version')
+    version.chomp.split("\n")[0].split(" ")[2] if version
+  end
+end

--- a/modules/maven/lib/puppet/parser/functions/snapshotbaseversion.rb
+++ b/modules/maven/lib/puppet/parser/functions/snapshotbaseversion.rb
@@ -1,0 +1,14 @@
+module Puppet::Parser::Functions
+  newfunction(:snapshotbaseversion, :type => :rvalue) do |args|
+    version = args[0]
+     # If the version is a Maven snapshot, transform the base version to it's
+     # SNAPSHOT indicator
+     regex = /^(.*)-[0-9]{8}\.[0-9]{6}-[0-9]+$/
+     if version =~ regex
+       base_version = regex.match(version)[1] + "-SNAPSHOT"     
+     else
+       base_version = version
+     end
+     base_version
+  end
+end

--- a/modules/maven/lib/puppet/provider/maven/mvn.rb
+++ b/modules/maven/lib/puppet/provider/maven/mvn.rb
@@ -1,0 +1,149 @@
+# Copyright 2011 MaestroDev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'puppet/resource'
+require 'puppet/resource/catalog'
+require 'fileutils'
+require 'tempfile'
+
+Puppet::Type.type(:maven).provide(:mvn) do
+  desc "Maven download using mvn command line."
+  include Puppet::Util::Execution
+
+  def ensure
+    if !exists?
+      :absent
+    elsif @resource[:ensure] == :latest && !outdated?
+      :latest
+    else
+      :present
+    end
+  end
+
+  def ensure=(value)
+    ([:present, :latest] & [value]).any? ? create(value) : destroy
+  end
+
+  private
+  [:artifactid,
+  :version,
+  :packaging,
+  :classifier,
+  :options,
+  :user,
+  :group,
+  :groupid,
+  :repoid].each { |m| define_method(m) { @resource[m] } }
+
+  [:user, :group].each do |m|
+    define_method(m) { @resource[m].nil? || @resource[m].empty? ? 'root' : @resource[m] }
+  end
+
+  def full_id
+    @resource[:id]
+  end
+
+  def plugin_version
+    @resource[:pluginversion].nil? ? "2.4" : @resource[:pluginversion]
+  end
+
+  def repos
+    repos = @resource[:repos]
+    if repos.nil? || repos.empty?
+      ["http://repo1.maven.apache.org/maven2"]
+    elsif !repos.kind_of?(Array)
+      [repos]
+    else
+      repos
+    end
+  end
+
+  def updatable?
+    if full_id.nil?
+      ver = version
+    else
+      ver = full_id.split(':')[2]
+    end
+
+    ver =~ /SNAPSHOT$/ || ver == 'LATEST' || ver == 'RELEASE'
+  end
+
+  def create(value)
+    download name, value == :latest
+  end
+
+  def download(dest, latest)
+    # Remote repositories to use
+    debug "Repositories to use: #{repos.join(', ')}"
+
+    # Download the artifact fom the repo
+    command_string = "-Dartifact=#{full_id}"
+    msg = full_id
+    if (full_id.nil?)
+      command_string = "-DgroupId=#{groupid} -DartifactId=#{artifactid} -Dversion=#{version} "
+      command_string = command_string + "-Dpackaging=#{packaging} " unless packaging.nil?
+      command_string = command_string + "-Dclassifier=#{classifier}" unless classifier.nil?
+      msg = "#{groupid}:#{artifactid}:#{version}:" + (packaging.nil? ? "" : packaging) + ":" + (classifier.nil? ? "" : classifier)
+    end
+
+    command_string = command_string + " -U " if updatable? && latest
+
+    # set the repoId if specified
+    command_string = command_string + " -DrepoId=#{repoid}" unless repoid.nil?
+
+    debug "mvn downloading (if needed) repo file #{msg} to #{dest} from #{repos.join(', ')}"
+
+    command = ["mvn org.apache.maven.plugins:maven-dependency-plugin:#{plugin_version}:get #{command_string} -DremoteRepositories=#{repos.join(',')} -Ddest=#{dest} -Dtransitive=false -Ppuppet-maven #{options}"]
+
+    timeout = @resource[:timeout].nil? ? 0 : @resource[:timeout].to_i
+    output = nil
+    status = nil
+
+    begin
+      Timeout::timeout(timeout) do
+        output, status = Puppet::Util::SUIDManager.run_and_capture(command, user, group)
+        debug output if status.exitstatus == 0
+        debug "Exit status = #{status.exitstatus}"
+      end
+    rescue Timeout::Error
+      self.fail("Command timed out, increase timeout parameter if needed: #{command}")
+    end
+
+    if (status.exitstatus == 1) && (output == '')
+      self.fail("mvn returned #{status.exitstatus}: Is Maven installed?")
+    end
+    unless status.exitstatus == 0
+      self.fail("#{command} returned #{status.exitstatus}: #{output}")
+    end
+  end
+
+  def destroy
+    # no going back
+    # FileUtils.rm @resource[:dest]
+    raise NotImplementedError
+  end
+
+  def exists?
+    # we could check if the file exists in the local repo but Buildr will do that before attempting to download it
+    return File.exists?(@resource[:name])
+  end
+
+  def outdated?
+    if updatable?
+      tempfile = Tempfile.new 'mvn'
+      download tempfile.path, true
+      !FileUtils.compare_file @resource[:name], tempfile.path
+    end
+  end
+end

--- a/modules/maven/lib/puppet/type/maven.rb
+++ b/modules/maven/lib/puppet/type/maven.rb
@@ -1,0 +1,111 @@
+# Copyright 2011 MaestroDev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'puppet/type'
+
+Puppet::Type.newtype(:maven) do
+  require 'timeout'
+
+  @doc = "Maven repository files."
+
+  newproperty(:ensure) do
+    desc <<-EOT
+      May be one of two values: 'present' or 'latest'.  When 'present' (the default)
+      the specified maven artifact is downloaded when no file exists
+      at 'path' (or 'name' if no path is specified.)  This is approporate
+      when the specified maven artifact refers to a released (non-SNAPSHOT)
+      artifact.  If 'latest' is specified and the value of version is
+      'RELEASE', 'LATEST', or a SNAPSHOT the repository is queried for the
+      most recent version.
+    EOT
+    defaultto(:present)
+
+    newvalue(:present)
+    newvalue(:latest)
+  end
+
+  # required or puppet will fail with one of these errors
+  # err: Could not render to pson: undefined method `merge' for []:Array
+  # Could not evaluate: No ability to determine if maven exists
+  def self.title_patterns
+    [ [ /^(.*?)\/*\Z/m, [ [ :path, lambda{|x| x} ] ] ] ]
+  end
+
+  newparam(:path) do
+    desc "The destination path of the downloaded file."
+    isnamevar
+  end
+
+  newparam(:id) do
+    desc "The Maven repository id, ie. 'org.apache.maven:maven-core:jar:3.0.5',
+      'org.apache.maven:maven-core:jar:sources:3.0.5'"
+  end
+  newparam(:groupid) do
+    desc "The Maven arifact group id, ie. 'org.apache.maven'"
+  end
+  newparam(:artifactid) do
+    desc "The Maven artifact id, ie. 'maven-core'"
+  end
+  newparam(:version) do
+    desc "The Maven artifact version, ie. '3.0.5'"
+  end
+  newparam(:packaging) do
+    desc "The Maven artifact packaging, ie. 'jar'"
+  end
+  newparam(:classifier) do
+    desc "The Maven artifact classifier, ie. 'sources'"
+  end
+
+  newparam(:repoid) do
+    desc "Id of the repository to use. Useful for mirroring, authentication,..."
+  end
+  newparam(:repos) do
+    desc "Repositories to use for artifact downloading. Defaults to http://repo1.maven.apache.org/maven2"
+  end
+  newparam(:timeout) do
+    desc "Download timeout."
+  end
+  newparam(:pluginversion) do
+    desc "Version of the dependency plugin to use."
+  end
+  newparam(:options) do
+    desc "Other options to pass to mvn."
+  end
+
+  newparam(:user) do
+    desc "User to run Maven as. Useful to share a local repo and settings.xml. Defaults to root."
+  end
+  newparam(:group) do
+    desc "Group to run Maven as. Defaults to root."
+  end
+
+  validate do
+    full_id = self[:id]
+    groupid = self[:groupid]
+    artifactid = self[:artifactid]
+    version = self[:version]
+    packaging = self[:packaging]
+    classifier = self[:classifier]
+
+    using_detailed_parameters = !groupid.nil? || !artifactid.nil? || !version.nil? || !packaging.nil? || !classifier.nil?
+    if (!full_id.nil? && using_detailed_parameters)
+      self.fail "Can't define id and other groupid, artifactid, version, packaging, classifier parameters at the same time"
+    end
+    if (using_detailed_parameters && (groupid.nil? || artifactid.nil? || version.nil?))
+      self.fail "Missing required groupid, artifactid or version parameters"
+    end
+
+  end
+
+end

--- a/modules/maven/manifests/buildr.pp
+++ b/modules/maven/manifests/buildr.pp
@@ -1,0 +1,40 @@
+# Copyright 2011 MaestroDev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Class: buildr
+#
+# A puppet recipe to install Apache Buildr
+#
+#
+class maven::buildr( $java_home ) {
+
+  # Can't use this as gem install buildr requires JAVA_HOME environment variable
+  # package { "buildr":
+  #   ensure   => "1.4.6",
+  #   provider => gem
+  # }
+
+  # a workaround using exec
+
+  notice('Installing buildr')
+
+  package { 'rake':
+    ensure   => '0.8.7',
+    provider => gem,
+  }
+  maven::install_gem { 'buildr' :
+    version => '1.4.5',
+    require => Package['rake'],
+  }
+}

--- a/modules/maven/manifests/configure.pp
+++ b/modules/maven/manifests/configure.pp
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a helper class that wraps the settings and environment defines.
+#
+# settings = {
+#   'uselessName' => {
+#     #see maven::settings for details
+#   }
+# }
+#
+# environments = {
+#   'uselessName' => {
+#     #see maven::environment for details
+#   }
+# }
+class maven::configure(
+  $settings = undef,
+  $environments = undef,
+) {
+
+  if $settings != undef {
+    create_resources('maven::settings', $settings)
+  }
+
+  if $settings != undef {
+    create_resources('maven::environment', $environments)
+  }
+
+}

--- a/modules/maven/manifests/environment.pp
+++ b/modules/maven/manifests/environment.pp
@@ -1,0 +1,36 @@
+# Copyright 2011 MaestroDev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define: maven::environment
+#
+# A puppet recipe to set the contents of the .mavenrc file
+#
+define maven::environment( $user, $home = undef, $maven_opts = '', $maven_path_additions = '', $mavenrc_additions = '' ) {
+
+  if $home == undef {
+    $home_real = $user ? {
+      'root'  => '/root',
+      default => "/home/${user}"
+    }
+  }
+  else {
+    $home_real = $home
+  }
+
+  file { "$home_real/.mavenrc":
+    mode    => '0600',
+    owner   => $user,
+    content => template('maven/mavenrc.erb'),
+  }
+}

--- a/modules/maven/manifests/init.pp
+++ b/modules/maven/manifests/init.pp
@@ -1,0 +1,40 @@
+# Copyright 2011 MaestroDev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Class: maven
+#
+# A puppet recipe for Apache Maven, to download artifacts
+# from a Maven repository
+#
+# It uses Apache Maven command line to download the artifacts.
+#
+# Parameters:
+#   - $version:
+#         Maven version.
+#
+# Requires:
+#   Java package installed.
+#
+# Sample Usage:
+#   class {'maven':
+#     version => "3.0.5",
+#   }
+#
+class maven() {
+
+  notice('Installing Maven module pre-requisites')
+
+  class { 'maven::maven': }
+
+}

--- a/modules/maven/manifests/install-gem.pp
+++ b/modules/maven/manifests/install-gem.pp
@@ -1,0 +1,12 @@
+define maven::install-gem ($version = '') {
+
+  warning('maven::install-gem is deprecated, use maven::install_gem')
+
+  exec { "gem $name $version":
+    path        => '/usr/bin:/opt/ruby/bin',
+    environment => "JAVA_HOME=$maven::java_home",
+    command     => "gem install $name --version $version --no-rdoc --no-ri",
+    unless      => "gem query -i --name-matches $name --version $version",
+    logoutput   => true,
+  }
+}

--- a/modules/maven/manifests/install_gem.pp
+++ b/modules/maven/manifests/install_gem.pp
@@ -1,0 +1,9 @@
+define maven::install_gem ($version = '') {
+  exec { "gem $name $version":
+    path        => '/usr/bin:/opt/ruby/bin',
+    environment => "JAVA_HOME=$maven::java_home",
+    command     => "gem install $name --version $version --no-rdoc --no-ri",
+    unless      => "gem query -i --name-matches $name --version $version",
+    logoutput   => true,
+  }
+}

--- a/modules/maven/manifests/maven.pp
+++ b/modules/maven/manifests/maven.pp
@@ -1,0 +1,77 @@
+# Copyright 2011 MaestroDev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Class: maven::maven
+#
+# A puppet recipe to install Apache Maven
+#
+# Parameters:
+#   - $version:
+#         Maven version.
+#
+# Requires:
+#   Java package installed.
+#
+# Sample Usage:
+#   class {'maven::maven':
+#     version => "3.0.5",
+#   }
+#
+class maven::maven(
+  $version = '3.0.5',
+  $repo = {
+    #url      => 'http://repo1.maven.org/maven2',
+    #username => '',
+    #password => '',
+  } ) {
+
+  $archive = "/tmp/apache-maven-${version}-bin.tar.gz"
+
+  # Avoid redownloading when tmp tar.gz is deleted
+  if $::maven_version != $version {
+
+    # we could use puppet-stdlib function !empty(repo) but avoiding adding a new
+    # dependency for now
+    if "x${repo['url']}x" != 'xx' {
+      wget::authfetch { 'fetch-maven':
+        source      => "${repo['url']}/org/apache/maven/apache-maven/$version/apache-maven-${version}-bin.tar.gz",
+        destination => $archive,
+        user        => $repo['username'],
+        password    => $repo['password'],
+        before      => Exec['maven-untar'],
+      }
+    } else {
+      wget::fetch { 'fetch-maven':
+        source      => "http://archive.apache.org/dist/maven/binaries/apache-maven-${version}-bin.tar.gz",
+        destination => $archive,
+        before      => Exec['maven-untar'],
+      }
+    }
+    exec { 'maven-untar':
+      command => "tar xf /tmp/apache-maven-${version}-bin.tar.gz",
+      cwd     => '/opt',
+      creates => "/opt/apache-maven-${version}",
+      path    => ['/bin','/usr/bin'],
+    }
+
+    file { '/usr/bin/mvn':
+      ensure  => link,
+      target  => "/opt/apache-maven-${version}/bin/mvn",
+      require => Exec['maven-untar'],
+    } ->
+    file { '/usr/local/bin/mvn':
+      ensure  => absent,
+    }
+  }
+}

--- a/modules/maven/manifests/settings.pp
+++ b/modules/maven/manifests/settings.pp
@@ -1,0 +1,94 @@
+# Copyright 2011 MaestroDev
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define: maven::settings
+#
+# A puppet recipe to set the contents of the settings.xml file
+#
+#
+# servers => [{
+#   id,
+#   username,
+#   password
+# },...]
+#
+# mirrors => [{
+#   id,
+#   url,
+#   mirrorOf
+# },...]
+#
+# properties => {
+#   key=>value
+# }
+#
+# repos => [{
+#   id,
+#   name, #optional
+#   url,
+#   releases => {
+#     key=>value
+#   },
+#   snapshots=> {
+#     key=>value
+#   }
+# },...]
+#
+# # Provided for backwards compatibility
+# # A shortcut to essentially add the central repo to the above list of repos.
+# default_repo_config => {
+#   url,
+#   releases => {
+#     key=>value
+#   },
+#   snapshots=> {
+#     key=>value
+#   }
+# }
+#
+# proxies => [{
+#   active, #optional, default to true
+#   protocol, #optional, defaults to http
+#   host,
+#   port,
+#   username,#optional
+#   password, #optional
+#   nonProxyHosts #optional
+# },...]
+define maven::settings( $home = undef, $user = 'root',
+  $servers = [], $mirrors = [], $default_repo_config = undef, $repos = [],
+  $properties = {}, $local_repo = '', $proxies=[]) {
+
+  if $home == undef {
+    $home_real = $user ? {
+      'root'  => '/root',
+      default => "/home/${user}"
+    }
+  }
+  else {
+    $home_real = $home
+  }
+
+  file { "${home_real}/.m2":
+    ensure => directory,
+    owner  => $user,
+    mode   => '0700',
+  } ->
+  file { "${home_real}/.m2/settings.xml":
+    owner   => $user,
+    mode    => '0600',
+    content => template('maven/settings.xml.erb'),
+  }
+
+}

--- a/modules/maven/metadata.json
+++ b/modules/maven/metadata.json
@@ -1,0 +1,145 @@
+{
+  "name": "maestrodev-maven",
+  "version": "1.1.7",
+  "source": "http://github.com/maestrodev/puppet-maven",
+  "author": "maestrodev",
+  "license": "Apache License, Version 2.0",
+  "summary": "Apache Maven module for Puppet",
+  "description": "A Puppet module to download artifacts from Maven repositories",
+  "project_page": "http://github.com/maestrodev/puppet-maven",
+  "dependencies": [
+    {
+      "name": "maestrodev/wget",
+      "version_requirement": ">=1.0.0"
+    }
+  ],
+  "types": [
+    {
+      "name": "maven",
+      "doc": "Maven repository files.",
+      "properties": [
+        {
+          "name": "ensure",
+          "doc": "      May be one of two values: 'present' or 'latest'.  When 'present' (the default)\n      the specified maven artifact is downloaded when no file exists\n      at 'path' (or 'name' if no path is specified.)  This is approporate\n      when the specified maven artifact refers to a released (non-SNAPSHOT)\n      artifact.  If 'latest' is specified and the value of version is\n      'RELEASE', 'LATEST', or a SNAPSHOT the repository is queried for the\n      most recent version.\n  Valid values are `present`, `latest`."
+        }
+      ],
+      "parameters": [
+        {
+          "name": "path",
+          "doc": "The destination path of the downloaded file."
+        },
+        {
+          "name": "id",
+          "doc": "The Maven repository id, ie. 'org.apache.maven:maven-core:jar:3.0.5',\n      'org.apache.maven:maven-core:jar:sources:3.0.5'"
+        },
+        {
+          "name": "groupid",
+          "doc": "The Maven arifact group id, ie. 'org.apache.maven'"
+        },
+        {
+          "name": "artifactid",
+          "doc": "The Maven artifact id, ie. 'maven-core'"
+        },
+        {
+          "name": "version",
+          "doc": "The Maven artifact version, ie. '3.0.5'"
+        },
+        {
+          "name": "packaging",
+          "doc": "The Maven artifact packaging, ie. 'jar'"
+        },
+        {
+          "name": "classifier",
+          "doc": "The Maven artifact classifier, ie. 'sources'"
+        },
+        {
+          "name": "repoid",
+          "doc": "Id of the repository to use. Useful for mirroring, authentication,..."
+        },
+        {
+          "name": "repos",
+          "doc": "Repositories to use for artifact downloading. Defaults to http://repo1.maven.apache.org/maven2"
+        },
+        {
+          "name": "timeout",
+          "doc": "Download timeout."
+        },
+        {
+          "name": "pluginversion",
+          "doc": "Version of the dependency plugin to use."
+        },
+        {
+          "name": "options",
+          "doc": "Other options to pass to mvn."
+        },
+        {
+          "name": "user",
+          "doc": "User to run Maven as. Useful to share a local repo and settings.xml. Defaults to root."
+        },
+        {
+          "name": "group",
+          "doc": "Group to run Maven as. Defaults to root."
+        }
+      ],
+      "providers": [
+        {
+          "name": "mvn",
+          "doc": "Maven download using mvn command line."
+        }
+      ]
+    }
+  ],
+  "checksums": {
+    "Gemfile": "7af3acbbb3a8be369945a46bcb1fc190",
+    "Gemfile.lock": "f2977ca4b651dadcafe42110f51543ca",
+    "LICENSE": "3b83ef96387f14655fc854ddc3c6bd57",
+    "Modulefile": "c0ed5e09a4890844fc2ece48a783128d",
+    "Puppetfile": "ffbfa1dee66bf4bf8db958d36bc710c5",
+    "Puppetfile.lock": "9bd55c56058d4003eb45481648b625f9",
+    "README.md": "b6b7deccbd6856ccfacd105c5940eb64",
+    "Rakefile": "1d8a34edcca1ada56caee7b96b8a9bb6",
+    "Vagrantfile": "a7ca2302b3450128d36e866d7f3781e0",
+    "lib/facter/maven_version.rb": "b8f07ca896a5da84f4f61a44389a6bc4",
+    "lib/puppet/parser/functions/snapshotbaseversion.rb": "04a9c5225aa266202ca7699d6934f515",
+    "lib/puppet/provider/maven/mvn.rb": "eddd3beb564c9c16e1440a1d4155681a",
+    "lib/puppet/type/maven.rb": "a8523957e4384c452b660b542839cd9e",
+    "manifests/buildr.pp": "2229539426e20cf286e547e4e631e9ef",
+    "manifests/configure.pp": "8c0ab3e2e4349e8b17958aa1d100f598",
+    "manifests/environment.pp": "50e56defef3a123a6629df3547259eb3",
+    "manifests/init.pp": "c2589c4c1dee9f3e510ddda520069b3e",
+    "manifests/install-gem.pp": "f4b2354eafad286eb160b71c6f2c3d38",
+    "manifests/install_gem.pp": "1118a2cee8e85960f84bafcbbf09d354",
+    "manifests/maven.pp": "bfc8a429fafd81c40df8605a8d1fd121",
+    "manifests/settings.pp": "ec5e72854506b05cdff7f675f815b45d",
+    "spec/classes/maven_spec.rb": "7aa7a05027d0b8f00342db730c6ce36d",
+    "spec/defines/complete-settings.xml": "93cd3fb1045c05b1335cc57527837459",
+    "spec/defines/default-mavenrc": "d41d8cd98f00b204e9800998ecf8427e",
+    "spec/defines/default-repo-only-url-settings.xml": "7f6e08fbc6e9bc0b4cf3a70f36fd08b9",
+    "spec/defines/default-repo-settings.xml": "3561cff50da7d88e17076b4051e73a17",
+    "spec/defines/default-settings.xml": "c32126be976d4cce94072d259d60c65d",
+    "spec/defines/environment_spec.rb": "aa88b2073dd9b3e78c49cd751e05971b",
+    "spec/defines/local-repo-settings.xml": "d5616742cec8e8607218c6b904a30a92",
+    "spec/defines/mirror-servers-settings.xml": "662435f74748748da087b16895c42cc3",
+    "spec/defines/populated-mavenrc": "f3ba57173b64666212ae64fcc2e0c8e3",
+    "spec/defines/properties-settings.xml": "77981a6e51efa1781a7adfb660a5d4d1",
+    "spec/defines/proxy-settings.xml": "58918c96c513e2e5649f42c65c8a29fd",
+    "spec/defines/settings_spec.rb": "621e49c1ae4004e1bee9522b540184b7",
+    "spec/fixtures/modules/wget/Gemfile": "4867df718b033e152c59c2a418e88b92",
+    "spec/fixtures/modules/wget/Gemfile.lock": "b3e4cf700f055d8d242ad877da298127",
+    "spec/fixtures/modules/wget/Modulefile": "319654cea17d4ad7af5a45f4746f6678",
+    "spec/fixtures/modules/wget/README.md": "53e3a8bdf9ad988aae9b9581831bbcd6",
+    "spec/fixtures/modules/wget/Rakefile": "527f8893f2694a9bc92993074f011cc3",
+    "spec/fixtures/modules/wget/manifests/init.pp": "7a1575c5a0a755b01dcdd2dbf4f8e956",
+    "spec/fixtures/modules/wget/spec/classes/init_spec.rb": "337ce66ffc43c7478ff0d3ff166d278a",
+    "spec/fixtures/modules/wget/spec/fixtures/manifests/site.pp": "627dec82fd1b0d0b4f9e47135ed3e1b7",
+    "spec/fixtures/modules/wget/spec/spec_helper.rb": "0db89c9a486df193c0e40095422e19dc",
+    "spec/spec_helper.rb": "cc65187d0436f0481de4f83a41179d37",
+    "spec/spec_helper_system.rb": "3c014d87d0033b34b5ace62f2a10e862",
+    "spec/system/maven_system_spec.rb": "26fc6afe9b45db3770433e1d574bf843",
+    "spec/unit/puppet/provider/maven/mvn_spec.rb": "1c86764b1736b96ba1cef73c7ad016c0",
+    "spec/unit/puppet/type/maven_spec.rb": "ba9d2fb1f50817a9c36d5dc11be21778",
+    "templates/mavenrc.erb": "319f01bd0b0ec202132d7338230f09a6",
+    "templates/settings.xml.erb": "ad0068b18196bcc816e3fc0e57476150",
+    "tests/init.pp": "5f811b0b07e068c555afb42c34d94928"
+  }
+}

--- a/modules/maven/spec/classes/maven_spec.rb
+++ b/modules/maven/spec/classes/maven_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'maven::maven' do
+  let(:title) { 'maven' }
+
+  context "when downloading maven" do
+    it do should contain_wget__fetch('fetch-maven').with(
+        'source'      => 'http://archive.apache.org/dist/maven/binaries/apache-maven-3.0.5-bin.tar.gz',
+        'user'        => nil,
+        'password'    => nil
+    ) end
+    it { should contain_exec('maven-untar') }
+  end
+
+  context "when downloading maven from another repo" do
+    let(:params) { { :repo => {
+        'url'      => 'http://repo1.maven.org/maven2',
+        'username' => 'u',
+        'password' => 'p'
+      }
+    } }
+
+    it 'should fetch maven with username and password' do
+      should contain_wget__authfetch('fetch-maven').with(
+        'source'      => 'http://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.0.5/apache-maven-3.0.5-bin.tar.gz',
+        'user'        => 'u',
+        'password'    => 'p')
+    end
+  end
+
+  context "when maven was already installed" do
+
+    context "in the same version" do
+      let(:facts) {{ :maven_version => '3.0.5' }}
+      it { should_not contain_wget__fetch('fetch-maven') }
+      it { should_not contain_exec('maven-untar') }
+    end
+
+    context "in a different version" do
+      let(:facts) {{ :maven_version => '3.0.4' }}
+      it { should contain_wget__fetch('fetch-maven') }
+      it { should contain_exec('maven-untar') }
+    end
+  end
+
+end

--- a/modules/maven/spec/defines/complete-settings.xml
+++ b/modules/maven/spec/defines/complete-settings.xml
@@ -1,0 +1,76 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <localRepository>/var/cache/maven/repository</localRepository>
+
+  <mirrors>
+    <mirror>
+      <id>maestro-mirror</id>
+      <url>http://localhost:8082/archiva/repository/all/</url>
+      <mirrorOf>external:*</mirrorOf>
+    </mirror>
+  </mirrors>
+
+  <servers>
+    <server>
+      <id>maestro-mirror</id>
+      <username>mirror_user</username>
+      <password>mirror_pass</password>
+    </server>
+    <server>
+      <id>maestro-deploy</id>
+      <username>deploy_user</username>
+      <password>deploy_pass</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>default-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://localhost:8082/archiva/repository/all/</url>
+          <snapshots>
+            <checksumPolicy>fail</checksumPolicy>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://localhost:8082/archiva/repository/all/</url>
+          <snapshots>
+            <checksumPolicy>fail</checksumPolicy>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+    <profile>
+      <id>properties</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <selenium.host>localhost</selenium.host>
+        <sonar.host.url>http://localhost:8083/sonar</sonar.host.url>
+        <sonar.jdbc.driverClassName>org.postgresql.Driver</sonar.jdbc.driverClassName>
+        <sonar.jdbc.password>password</sonar.jdbc.password>
+        <sonar.jdbc.url>jdbc:postgresql://localhost:5432/sonar</sonar.jdbc.url>
+        <sonar.jdbc.username>user</sonar.jdbc.username>
+      </properties>
+    </profile>
+  </profiles>
+
+</settings>

--- a/modules/maven/spec/defines/default-repo-only-url-settings.xml
+++ b/modules/maven/spec/defines/default-repo-only-url-settings.xml
@@ -1,0 +1,25 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>default-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://localhost:8082/archiva/repository/all/</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://localhost:8082/archiva/repository/all/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/modules/maven/spec/defines/default-repo-settings.xml
+++ b/modules/maven/spec/defines/default-repo-settings.xml
@@ -1,0 +1,39 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>default-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>http://localhost:8082/archiva/repository/all/</url>
+          <snapshots>
+            <checksumPolicy>fail</checksumPolicy>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>central</id>
+          <url>http://localhost:8082/archiva/repository/all/</url>
+          <snapshots>
+            <checksumPolicy>fail</checksumPolicy>
+            <enabled>true</enabled>
+          </snapshots>
+          <releases>
+            <checksumPolicy>fail</checksumPolicy>
+          </releases>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/modules/maven/spec/defines/default-settings.xml
+++ b/modules/maven/spec/defines/default-settings.xml
@@ -1,0 +1,4 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+</settings>

--- a/modules/maven/spec/defines/environment_spec.rb
+++ b/modules/maven/spec/defines/environment_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe "maven::environment" do
+  let(:title) { 'environment' }
+  let(:params) { {
+      :user => "u",
+  } }
+
+  expected_filename = '/home/u/.mavenrc'
+  it { should contain_file(expected_filename).with_owner('u') }
+
+  it 'should generate valid mavenrc' do
+    content = catalogue.resource('file', expected_filename).send(:parameters)[:content]
+    content.should == read_file("default-mavenrc")
+  end
+
+  context "provide options for mavenrc" do
+    let(:params) {{
+        :user => "u",
+        :maven_opts => "-Xmx256m",
+        :maven_path_additions => "/usr/local/bin",
+        :mavenrc_additions => "echo Hello World!"
+    }}
+
+    it 'should generate valid mavenrc' do
+      content = catalogue.resource('file', expected_filename).send(:parameters)[:content]
+      content.should == read_file("populated-mavenrc")
+    end
+
+  end
+
+end
+
+def read_file(filename)
+  IO.read(File.expand_path(filename, File.dirname(__FILE__)))
+end

--- a/modules/maven/spec/defines/local-repo-settings.xml
+++ b/modules/maven/spec/defines/local-repo-settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <localRepository>/var/cache/maven/repository</localRepository>
+
+</settings>

--- a/modules/maven/spec/defines/mirror-servers-settings.xml
+++ b/modules/maven/spec/defines/mirror-servers-settings.xml
@@ -1,0 +1,25 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <mirrors>
+    <mirror>
+      <id>maestro-mirror</id>
+      <url>http://localhost:8082/archiva/repository/all/</url>
+      <mirrorOf>external:*</mirrorOf>
+    </mirror>
+  </mirrors>
+
+  <servers>
+    <server>
+      <id>maestro-mirror</id>
+      <username>mirror_user</username>
+      <password>mirror_pass</password>
+    </server>
+    <server>
+      <id>maestro-deploy</id>
+      <username>deploy_user</username>
+      <password>deploy_pass</password>
+    </server>
+  </servers>
+
+</settings>

--- a/modules/maven/spec/defines/populated-mavenrc
+++ b/modules/maven/spec/defines/populated-mavenrc
@@ -1,0 +1,3 @@
+export MAVEN_OPTS="-Xmx256m $MAVEN_OPTS"
+export PATH="/usr/local/bin:$PATH"
+echo Hello World!

--- a/modules/maven/spec/defines/properties-settings.xml
+++ b/modules/maven/spec/defines/properties-settings.xml
@@ -1,0 +1,21 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>properties</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <selenium.host>localhost</selenium.host>
+        <sonar.host.url>http://localhost:8083/sonar</sonar.host.url>
+        <sonar.jdbc.driverClassName>org.postgresql.Driver</sonar.jdbc.driverClassName>
+        <sonar.jdbc.password>password</sonar.jdbc.password>
+        <sonar.jdbc.url>jdbc:postgresql://localhost:5432/sonar</sonar.jdbc.url>
+        <sonar.jdbc.username>user</sonar.jdbc.username>
+      </properties>
+    </profile>
+  </profiles>
+
+</settings>

--- a/modules/maven/spec/defines/proxy-settings.xml
+++ b/modules/maven/spec/defines/proxy-settings.xml
@@ -1,0 +1,15 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <proxies>
+    <proxy>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>http://proxy.acme.com</host>
+      <username>myuser</username>
+      <password>mypassword</password>
+      <nonProxyHosts>www.acme.com</nonProxyHosts>
+    </proxy>
+  </proxies>
+
+</settings>

--- a/modules/maven/spec/defines/settings_spec.rb
+++ b/modules/maven/spec/defines/settings_spec.rb
@@ -1,0 +1,156 @@
+require 'spec_helper'
+
+shared_examples :maven_settings do |expected_file|
+
+  def read_file(filename)
+    IO.read(File.expand_path(filename, File.dirname(__FILE__)))
+  end
+
+  it { should contain_file(expected_filename).with_owner('u') }
+
+  it 'should generate valid settings.xml' do
+    should contain_file(expected_filename).with_content(read_file(expected_file))
+  end
+end
+
+describe "maven::settings" do
+  let(:title) { 'settings' }
+  let(:params) { {
+      :user => "u",
+      :home => "/home/u",
+  } }
+
+  let(:url) { 'http://localhost:8082/archiva/repository/all/' }
+  let(:mirror) {{
+    'id' => 'maestro-mirror',
+    'url' => url,
+    'mirrorof' => 'external:*',
+  }}
+  let(:mirror_server) {{
+    'id' => 'maestro-mirror',
+    'username' => 'mirror_user',
+    'password' => 'mirror_pass',
+  }}
+  let(:deploy_server) {{
+    'id' => 'maestro-deploy',
+    'username' => 'deploy_user',
+    'password' => 'deploy_pass',
+  }}
+  let(:default_repo_config) {{
+    'url' => url,
+    'snapshots' => {
+        'enabled' => 'true',
+        'checksumPolicy' => 'fail',
+    },
+    'releases' => {
+        'checksumPolicy' => 'fail',
+    }
+  }}
+  let(:proxy) {{
+    'active' => true,
+    'protocol' => 'http',
+    'host' => 'http://proxy.acme.com',
+    'username' => 'myuser',
+    'password' => 'mypassword',
+    'nonProxyHosts' => 'www.acme.com',
+  }}
+  let(:properties) {{
+    'sonar.jdbc.url' => 'jdbc:postgresql://localhost:5432/sonar',
+    'sonar.jdbc.driverClassName' => 'org.postgresql.Driver',
+    'sonar.jdbc.username' => 'user',
+    'sonar.jdbc.password' => 'password',
+    'sonar.host.url' => 'http://localhost:8083/sonar',
+    'selenium.host' => 'localhost',
+  }}
+
+  let(:expected_filename) { '/home/u/.m2/settings.xml' }
+
+  it_behaves_like :maven_settings, "default-settings.xml"
+
+  context "with empty default_repo_config" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :default_repo_config => {},
+      }}
+
+    it_behaves_like :maven_settings, "default-settings.xml"
+  end
+
+  context "with mirrors and settings" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :mirrors => [mirror],
+          :servers => [mirror_server, deploy_server]
+      }}
+
+    it_behaves_like :maven_settings, "mirror-servers-settings.xml"
+  end
+
+  context "with default repository" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :default_repo_config => default_repo_config,
+      }}
+
+    it_behaves_like :maven_settings, "default-repo-settings.xml"
+  end
+
+  context "with default repository configuration url only" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :default_repo_config => {
+              'url' => default_repo_config['url'],
+          },
+      }}
+
+    it_behaves_like :maven_settings, "default-repo-only-url-settings.xml"
+  end
+
+  context "with properties" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :properties => properties,
+      }}
+
+    it_behaves_like :maven_settings, "properties-settings.xml"
+  end
+
+  context "with local repository" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :local_repo => "/var/cache/maven/repository",
+      }}
+
+    it_behaves_like :maven_settings, "local-repo-settings.xml"
+  end
+
+  context "with proxy" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :proxies => [proxy],
+      }}
+
+    it_behaves_like :maven_settings, "proxy-settings.xml"
+  end
+
+  context "with the lot" do
+    let(:params) {{
+          :user => "u",
+          :home => "/home/u",
+          :mirrors => [mirror],
+          :servers => [mirror_server, deploy_server],
+          :default_repo_config => default_repo_config,
+          :properties => properties,
+          :local_repo => "/var/cache/maven/repository",
+      }}
+
+    it_behaves_like :maven_settings, "complete-settings.xml"
+  end
+end

--- a/modules/maven/spec/fixtures/modules/wget/Gemfile
+++ b/modules/maven/spec/fixtures/modules/wget/Gemfile
@@ -1,0 +1,9 @@
+source :rubygems
+
+group :rake do
+  gem 'puppet',       '~>2.7.17'
+  gem 'rspec-puppet', '>=0.1.3'
+  gem 'rake',         '>=0.9.2.2'
+  gem 'puppet-lint',  '~>0.1.12'
+  gem 'puppetlabs_spec_helper'
+end

--- a/modules/maven/spec/fixtures/modules/wget/Gemfile.lock
+++ b/modules/maven/spec/fixtures/modules/wget/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    diff-lcs (1.1.3)
+    facter (1.6.10)
+    metaclass (0.0.1)
+    mocha (0.12.0)
+      metaclass (~> 0.0.1)
+    puppet (2.7.18)
+      facter (~> 1.5)
+    puppet-lint (0.1.13)
+    puppetlabs_spec_helper (0.2.0)
+      mocha (>= 0.10.5)
+      rake
+      rspec (>= 2.9.0)
+      rspec-puppet (>= 0.1.1)
+    rake (0.9.2.2)
+    rspec (2.11.0)
+      rspec-core (~> 2.11.0)
+      rspec-expectations (~> 2.11.0)
+      rspec-mocks (~> 2.11.0)
+    rspec-core (2.11.0)
+    rspec-expectations (2.11.1)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.11.1)
+    rspec-puppet (0.1.3)
+      rspec
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puppet (~> 2.7.17)
+  puppet-lint (~> 0.1.12)
+  puppetlabs_spec_helper
+  rake (>= 0.9.2.2)
+  rspec-puppet (>= 0.1.3)

--- a/modules/maven/spec/fixtures/modules/wget/Modulefile
+++ b/modules/maven/spec/fixtures/modules/wget/Modulefile
@@ -1,0 +1,8 @@
+name    'maestrodev-wget'
+version '1.1.0'
+source 'http://github.com/maestrodev/puppet-wget.git'
+author 'maestrodev'
+license 'Apache License, Version 2.0'
+summary 'Download files with wget'
+description 'A module for wget that allows downloading of files, supporting authentication'
+project_page 'http://github.com/maestrodev/puppet-wget'

--- a/modules/maven/spec/fixtures/modules/wget/README.md
+++ b/modules/maven/spec/fixtures/modules/wget/README.md
@@ -1,0 +1,37 @@
+A Puppet module to download files with wget, supporting authentication.
+
+# Example
+
+	include wget
+	
+	wget::fetch { "download":
+	  source      => "http://www.google.com/index.html",
+	  destination => "/tmp/index.html",
+	  timeout     => 0,
+	  verbose     => false,
+	}
+	
+	wget::authfetch { "download":
+	  source      => "http://www.google.com/index.html",
+	  destination => "/tmp/index.html",
+	  user        => "user",
+	  password    => "password",
+	  timeout     => 0,
+	  verbose     => false,
+	}
+
+# License
+
+Copyright 2011-2013 MaestroDev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/modules/maven/spec/fixtures/modules/wget/Rakefile
+++ b/modules/maven/spec/fixtures/modules/wget/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler'
+Bundler.require(:rake)
+
+require 'puppetlabs_spec_helper/rake_tasks'
+
+PuppetLint.configuration.send("disable_80chars")

--- a/modules/maven/spec/fixtures/modules/wget/manifests/init.pp
+++ b/modules/maven/spec/fixtures/modules/wget/manifests/init.pp
@@ -1,0 +1,98 @@
+################################################################################
+# Class: wget
+#
+# This class will install wget - a tool used to download content from the web.
+#
+################################################################################
+class wget($version='installed') {
+  
+  if $::operatingsystem != 'Darwin' {
+    package { "wget": ensure => $version }
+  }
+}
+
+################################################################################
+# Definition: wget::fetch
+#
+# This class will download files from the internet.  You may define a web proxy
+# using $http_proxy if necessary.
+#
+################################################################################
+define wget::fetch($source,$destination,$timeout="0",$verbose=false) {
+  include wget
+  # using "unless" with test instead of "creates" to re-attempt download
+  # on empty files.
+  # wget creates an empty file when a download fails, and then it wouldn't try
+  # again to download the file
+  if $::http_proxy {
+    $environment = [ "HTTP_PROXY=$::http_proxy", "http_proxy=$::http_proxy" ]
+  }
+  else {
+    $environment = []
+  }
+
+  $verbose_option = $verbose ? {
+    true  => "--verbose",
+    false => "--no-verbose"
+  }
+
+  exec { "wget-$name":
+    command => "wget $verbose_option --output-document=$destination $source",
+    timeout => $timeout,
+    unless => "test -s $destination",
+    environment => $environment,
+    path => "/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin",
+    require => Class[wget],
+  }
+}
+
+################################################################################
+# Definition: wget::authfetch
+#
+# This class will download files from the internet.  You may define a web proxy
+# using $http_proxy if necessary. Username must be provided. And the user's
+# password must be stored in the password variable within the .wgetrc file.
+#
+################################################################################
+define wget::authfetch($source,$destination,$user,$password="",$timeout="0",$verbose=false) {
+  include wget
+  if $http_proxy {
+    $environment = [ "HTTP_PROXY=$http_proxy", "http_proxy=$http_proxy", "WGETRC=/tmp/wgetrc-$name" ]
+  }
+  else {
+    $environment = [ "WGETRC=/tmp/wgetrc-$name" ]
+  }
+
+  $verbose_option = $verbose ? {
+    true  => "--verbose",
+    false => "--no-verbose"
+  }
+  
+  case $::operatingsystem {
+    'Darwin': {
+      # This is to work around an issue with macports wget and out of date CA cert bundle.  This requires 
+      # installing the curl-ca-bundle package like so:
+      #
+      # sudo port install curl-ca-bundle      
+      $wgetrc_content = "password=$password\nCA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt\n"
+     } 
+     default: {
+      $wgetrc_content = "password=$password"
+    }
+  }
+  
+  file { "/tmp/wgetrc-$name":
+    owner => root,
+    mode => 600,
+    content => $wgetrc_content,
+  } ->
+  exec { "wget-$name":
+    command => "wget $verbose_option --user=$user --output-document=$destination $source",
+    timeout => $timeout,
+    unless => "test -s $destination",
+    environment => $environment,
+    path => "/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin",
+    require => Class[wget],
+  }
+}
+

--- a/modules/maven/spec/fixtures/modules/wget/metadata.json
+++ b/modules/maven/spec/fixtures/modules/wget/metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "maestrodev-wget",
+  "version": "1.1.0",
+  "source": "http://github.com/maestrodev/puppet-wget.git",
+  "author": "maestrodev",
+  "license": "Apache License, Version 2.0",
+  "summary": "Download files with wget",
+  "description": "A module for wget that allows downloading of files, supporting authentication",
+  "project_page": "http://github.com/maestrodev/puppet-wget",
+  "dependencies": [
+
+  ],
+  "types": [
+
+  ],
+  "checksums": {
+    "Gemfile": "4867df718b033e152c59c2a418e88b92",
+    "Gemfile.lock": "b3e4cf700f055d8d242ad877da298127",
+    "Modulefile": "319654cea17d4ad7af5a45f4746f6678",
+    "README.md": "53e3a8bdf9ad988aae9b9581831bbcd6",
+    "Rakefile": "527f8893f2694a9bc92993074f011cc3",
+    "manifests/init.pp": "7a1575c5a0a755b01dcdd2dbf4f8e956",
+    "spec/classes/init_spec.rb": "337ce66ffc43c7478ff0d3ff166d278a",
+    "spec/fixtures/manifests/site.pp": "627dec82fd1b0d0b4f9e47135ed3e1b7",
+    "spec/spec_helper.rb": "0db89c9a486df193c0e40095422e19dc"
+  }
+}

--- a/modules/maven/spec/fixtures/modules/wget/spec/classes/init_spec.rb
+++ b/modules/maven/spec/fixtures/modules/wget/spec/classes/init_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'wget' do
+
+  context 'running on OS X' do
+    let(:facts) { {:operatingsystem => 'Darwin'} }
+
+    it { should_not contain_package('wget') }
+  end
+
+  context 'running on CentOS' do
+    let(:facts) { {:operatingsystem => 'CentOS'} }
+
+    it { should contain_package('wget') }
+  end
+
+  context 'no version specified' do
+    it { should contain_package('wget').with_ensure('installed') }
+  end
+
+  context 'version is 1.2.3' do
+    let(:params) { {:version => '1.2.3'} }
+
+    it { should contain_package('wget').with_ensure('1.2.3') }
+  end
+
+  describe 'wget::fetch' do
+    it { should contain_exec('wget-test').with_command('wget --no-verbose --output-document=/tmp/dest http://localhost/source') }
+  end
+
+  describe 'wget::authfetch' do
+    it { should contain_exec('wget-authtest').with({
+      'command'     => 'wget --no-verbose --user=myuser --output-document=/tmp/dest http://localhost/source',
+      'environment' => 'WGETRC=/tmp/wgetrc-authtest'
+      })
+    }
+    it { should contain_file('/tmp/wgetrc-authtest').with_content('password=mypassword') }
+  end
+end

--- a/modules/maven/spec/fixtures/modules/wget/spec/fixtures/manifests/site.pp
+++ b/modules/maven/spec/fixtures/modules/wget/spec/fixtures/manifests/site.pp
@@ -1,0 +1,11 @@
+wget::fetch { 'test':
+  source      => 'http://localhost/source',
+  destination => '/tmp/dest',
+}
+
+wget::authfetch { 'authtest':
+  source      => 'http://localhost/source',
+  destination => '/tmp/dest',
+  user        => 'myuser',
+  password    => 'mypassword',
+}

--- a/modules/maven/spec/fixtures/modules/wget/spec/spec_helper.rb
+++ b/modules/maven/spec/fixtures/modules/wget/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'

--- a/modules/maven/spec/spec_helper.rb
+++ b/modules/maven/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+require 'puppet'
+
+RSpec.configure do |c|
+  c.mock_with :rspec
+
+  c.before(:each) do
+    Puppet::Util::Log.level = :warning
+    Puppet::Util::Log.newdestination(:console)
+  end
+
+end

--- a/modules/maven/spec/spec_helper_system.rb
+++ b/modules/maven/spec/spec_helper_system.rb
@@ -1,0 +1,42 @@
+require 'puppet'
+require 'rspec-system/spec_helper'
+require 'rspec-system-puppet/helpers'
+require 'rspec-system-serverspec/helpers'
+
+include RSpecSystemPuppet::Helpers
+include Serverspec::Helper::RSpecSystem
+
+RSpec.configure do |c|
+  # Enable color in Jenkins
+  c.tty = true
+
+  c.before(:each) do
+    Puppet::Util::Log.level = :warning
+    Puppet::Util::Log.newdestination(:console)
+  end
+
+  c.before :suite do
+    #Install puppet
+    puppet_install
+
+    #Clean out modules from last run
+    shell 'rm -rf /etc/puppet/modules/*'
+
+    shell 'puppet module install maestrodev/wget -v 1.0.0'
+    shell 'puppet module install puppetlabs/java -v 1.0.1'
+
+    puppet_module_install source: proj_dir, module_name: 'maven'
+
+    #geezes
+    shell 'puppet module install spiette/selinux -v 0.5.3'
+    puppet_apply "class{'selinux': mode => 'disabled'}"
+  end
+end
+
+def fixture_rcp(src, dest)
+  rcp sp: "#{proj_dir}/spec/fixtures/#{src}", dp: dest
+end
+
+def proj_dir
+  File.absolute_path File.join File.dirname(__FILE__), '..'
+end

--- a/modules/maven/spec/system/maven_system_spec.rb
+++ b/modules/maven/spec/system/maven_system_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper_system'
+
+describe 'maven type' do
+  before(:all) do
+    puppet_apply (%Q(
+class { 'java': }
+class { 'maven::maven': }
+     ))
+  end
+
+  it 'should be idempotent' do
+    pp = %Q(
+      maven { '/tmp/maven-core-3.0.5.jar':
+        id     => 'org.apache.maven:maven-core:3.0.5:jar',
+        repos  => [
+          'central::default::http://repo1.maven.apache.org/maven2',
+          'http://mirrors.ibiblio.org/pub/mirrors/maven2'],
+      }
+    )
+    puppet_apply pp
+    puppet_apply(pp) do |r|
+      expect(r.exit_code).to equal 0
+    end
+  end
+
+  context 'an existing SNAPSHOT artifact' do
+    let(:version) { '0.0.1-SNAPSHOT' }
+    let(:ensure_param) { 'present' }
+    let(:repo_version) { 1 }
+
+    before(:each) do
+      shell 'rm -rf /var/www/html/repo'
+      shell 'rm -rf /root/.m2/repository/org/foo'
+      shell 'rm -f /tmp/touch-me-if-updated'
+
+      shell 'mkdir -p /var/www/html'
+      fixture_rcp "system/maven/repo-#{repo_version}", '/var/www/html/repo'
+
+      puppet_apply(%Q(
+        package{'httpd': ensure => 'present'} ->
+        service{'httpd': ensure  => 'running' } ->
+
+        maven { '/tmp/hello.jar':
+          ensure => '#{ensure_param}',
+          id     => 'org.foo:hello:#{version}',
+          repos  => 'http://localhost/repo'
+        }
+
+        exec{'touch-me':
+          command => '/bin/touch /tmp/touch-me-if-updated',
+          refreshonly => true,
+          subscribe => Maven['/tmp/hello.jar']
+        }
+      ))
+    end
+
+    describe file('/tmp/hello.jar') do
+      it 'should have have the original version' do
+        should match_md5checksum '807f2fca0e279dbe48f695983141fd5c'
+      end
+    end
+
+    context 'with the same SNAPSHOT in the repote repo' do
+      let(:repo_version) { 1 }
+
+      around(:each) do |example|
+        #make sure the v1 verson of the SNAPSHOT is on the filesystem
+        fixture_rcp 'system/maven/repo-1/org/foo/hello/0.0.1-SNAPSHOT/hello-0.0.1-20131008.014634-1.jar', '/tmp/hello.jar'
+        example.run
+      end
+
+      context 'and ensure => latest' do
+        let(:ensure_param) { 'latest' }
+
+        describe file('/tmp/hello.jar') do
+          it 'should have the same snapshot' do
+            should match_md5checksum  '807f2fca0e279dbe48f695983141fd5c'
+          end
+        end
+
+        describe file('/tmp/touch-me-if-updated') do
+          it 'should not have been created by subscribe relationship' do
+            should_not be_file
+          end
+        end
+      end
+    end
+
+    context 'with an updated SNAPSHOT in the remote repo' do
+      let(:repo_version) { 2 }
+
+      around(:each) do |example|
+        #make sure the v1 verson of the SNAPSHOT is on the filesystem
+        fixture_rcp 'system/maven/repo-1/org/foo/hello/0.0.1-SNAPSHOT/hello-0.0.1-20131008.014634-1.jar', '/tmp/hello.jar'
+        example.run
+      end
+
+      context 'and ensure => present' do
+        let(:ensure_param) { 'present' }
+
+        describe file('/tmp/hello.jar') do
+          it 'should still have have the original version' do
+            should match_md5checksum '807f2fca0e279dbe48f695983141fd5c'
+          end
+        end
+
+        describe file('/tmp/touch-me-if-updated') do
+          it 'should not have been created by subscribe relationship' do
+            should_not be_file
+          end
+        end
+      end
+
+      context 'and ensure => latest' do
+        let(:ensure_param) { 'latest' }
+
+        describe file('/tmp/hello.jar') do
+          it 'should have the updated snapshot' do
+            should match_md5checksum '67fce35a2a7227a53cdcde06b86d33bf'
+          end
+        end
+
+        describe file('/tmp/touch-me-if-updated') do
+          it 'should have been created by subscribe relationship' do
+            should be_file
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/maven/spec/unit/puppet/provider/maven/mvn_spec.rb
+++ b/modules/maven/spec/unit/puppet/provider/maven/mvn_spec.rb
@@ -1,0 +1,464 @@
+require 'spec_helper'
+require 'tempfile'
+
+type = Puppet::Type.type(:maven)
+provider_class = type.provider(:mvn)
+
+describe provider_class do
+  subject { provider_class.new type.new({ path: path }.merge params) }
+  let(:params) { { } }
+
+  context 'if the file exists' do
+    let(:path) do
+      file = Tempfile.new 'tmp'
+      file_path = file.path
+      file.close!
+      File.open(file_path, 'w') do |f|
+        f.write 'blah'
+      end
+
+      file_path
+    end
+
+    its(:exists?) { should be_true }
+
+    example do
+      expect { subject.ensure = :absent }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#ensure' do
+    subject { provider_class.new(type.new({ path: path, ensure: ensure_param }.merge params)).ensure }
+
+    context 'with an existing file' do
+      let(:path) do
+        file = Tempfile.new 'tmp'
+        file_path = file.path
+        file.close!
+        File.open(file_path, 'w') do |f|
+          f.write 'foo'
+        end
+
+        file_path
+      end
+
+      context 'and ensure => latest' do
+        let(:ensure_param) { 'latest' }
+
+        context 'and a SNAPSHOT version' do
+          let(:params) { { id: 'groupid:artifactid:1.2.3-SNAPSHOT' } }
+
+          context 'and an updated snapshot' do
+            before do
+              expect(Puppet::Util::SUIDManager).to receive(:run_and_capture) { |command|
+                command[0] =~ /-Ddest=([^\s]+)/
+                File.open($1, 'w') do |f|
+                  f.write 'bar'
+                end
+              }.and_return ['', OpenStruct.new({exitstatus: 0})]
+            end
+
+            it { should equal :present }
+          end
+
+          context 'and a current snapshot' do
+            before do
+              expect(Puppet::Util::SUIDManager).to receive(:run_and_capture) { |command|
+                command[0] =~ /-Ddest=([^\s]+)/
+                File.open($1, 'w') do |f|
+                  f.write 'foo'
+                end
+              }.and_return ['', OpenStruct.new({exitstatus: 0})]
+            end
+
+            it { should equal :latest }
+          end
+        end
+      end
+
+      context 'and ensure => present' do
+        let(:ensure_param) { 'present' }
+
+        context 'and a SNAPSHOT version' do
+          let(:params) { { id: 'groupid:artifactid:1.2.3-SNAPSHOT' } }
+
+          context 'and an updated snapshot' do
+            it { should equal :present }
+          end
+
+          context 'and a current snapshot' do
+            it { should equal :present }
+          end
+        end
+      end
+    end
+  end
+
+  context 'if the file does not exist' do
+    let(:path) do
+      file = Tempfile.new 'tmp'
+      file_path = file.path
+      file.close!
+      file_path
+    end
+
+    its(:exists?) { should be_false }
+  end
+
+  describe '#ensure=' do
+    subject { provider_class.new(type.new({ path: path }.merge params)).ensure = ensure_param }
+
+    context 'with ensure => latest' do
+      let(:ensure_param) { :latest }
+      let(:exitstatus) { OpenStruct.new exitstatus: 0 }
+
+      context 'given a valid path' do
+        let(:path) { '/tmp/blah.txt' }
+
+        describe 'maven command line' do
+          subject do
+            command_line = nil
+
+            expect(Puppet::Util::SUIDManager).to receive(:run_and_capture) { |command|
+              command_line = command[0]
+            }.and_return [nil, exitstatus]
+            provider_class.new(type.new({ path: path }.merge params)).ensure = ensure_param
+            command_line
+          end
+
+          it 'should not pass -U' do
+            should_not match /-U/
+          end
+
+          context 'given a SNAPSHOT version' do
+            let(:params) do
+              {
+                groupid: 'groupid_test',
+                artifactid: 'artifactid_test',
+                version: '1.2.3-SNAPSHOT'
+              }
+            end
+
+            it 'should pass -U' do
+              should match /-U/
+            end
+          end
+
+          context 'given the version LATEST' do
+            let(:params) do
+              {
+                groupid: 'groupid_test',
+                artifactid: 'artifactid_test',
+                version: 'LATEST'
+              }
+            end
+
+            it 'should pass -U' do
+              should match /-U/
+            end
+          end
+
+          context 'given the version RELEASE' do
+            let(:params) do
+              {
+                groupid: 'groupid_test',
+                artifactid: 'artifactid_test',
+                version: 'LATEST'
+              }
+            end
+
+            it 'should pass -U' do
+              should match /-U/
+            end
+          end
+        end
+      end
+    end
+
+    context 'with ensure => present' do
+      let(:ensure_param) { :present }
+      let(:exitstatus) { OpenStruct.new exitstatus: 0 }
+
+      context 'given a valid path' do
+        let(:path) { '/tmp/blah.txt' }
+
+        context 'when mvn returns 1' do
+          let(:exitstatus) { OpenStruct.new exitstatus: 1 }
+
+          context 'with no output' do
+            let(:output) { '' }
+
+            example do
+              expect(Puppet::Util::SUIDManager).to receive(:run_and_capture)
+                .and_return [output, exitstatus]
+              expect { subject }.to raise_error Puppet::Error, /^mvn returned 1: Is Maven installed\?/
+            end
+          end
+
+          context 'with output "busted!"' do
+            let(:output) { 'busted!' }
+
+            example do
+              expect(Puppet::Util::SUIDManager).to receive(:run_and_capture)
+                .and_return [output, exitstatus]
+              expect { subject }.to raise_error Puppet::Error, /returned 1: busted\!/
+            end
+          end
+        end
+
+        it 'should default to root user' do
+          expect(Puppet::Util::SUIDManager).to receive(:run_and_capture)
+            .with(anything(), 'root', anything())
+            .and_return [nil, exitstatus]
+
+          subject
+        end
+
+        it 'should default to root group' do
+          expect(Puppet::Util::SUIDManager).to receive(:run_and_capture)
+            .with(anything(), anything(), 'root')
+            .and_return [nil, exitstatus]
+
+          subject
+        end
+
+        it 'should use no timeout' do
+          expect(Timeout).to receive(:timeout).with(0).and_call_original
+          expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).and_return [nil, exitstatus]
+
+          subject
+        end
+
+        describe 'maven command line' do
+          subject do
+            command_line = nil
+
+            expect(Puppet::Util::SUIDManager).to receive(:run_and_capture) { |command|
+              command_line = command[0]
+            }.and_return [nil, exitstatus]
+            provider_class.new(type.new({ path: path }.merge params)).ensure = :present
+            command_line
+          end
+
+          it 'should include path' do
+            should match /-Ddest=\/tmp\/blah\.txt/
+          end
+
+          it 'should default to plugin version 2.4' do
+            should match /mvn org\.apache\.maven\.plugins:maven-dependency-plugin:2\.4:get/
+          end
+
+          it 'should pass no repoId' do
+            should_not match /-DrepoId=/
+          end
+
+          it 'should pass no artifact coordinates' do
+            should_not match /-Dartifact=/
+          end
+
+          it 'should pass no packaging' do
+            should_not match /-Dpackaging=/
+          end
+
+          it 'should pass no classifier' do
+            should_not match /-Dclassifier=/
+          end
+
+          it 'should not pass -U' do
+            should_not match /-U/
+          end
+
+          context 'given a SNAPSHOT version' do
+            let(:params) do
+              {
+                groupid: 'groupid_test',
+                artifactid: 'artifactid_test',
+                version: '1.2.3-SNAPSHOT'
+              }
+            end
+
+            it 'should not pass -U' do
+              should_not match /-U/
+            end
+          end
+
+          context 'and a groupId, artifactId, and version' do
+            let(:params) do
+              {
+                groupid: 'groupid_test',
+                artifactid: 'artifactid_test',
+                version: 'version_test'
+              }
+            end
+
+            it 'should pass the provided artifactid' do
+              should match /-DartifactId=artifactid_test/
+            end
+
+            it 'should pass the provided groupid' do
+              should match /-DgroupId=groupid_test/
+            end
+
+            it 'should pass the provided version' do
+              should match /-Dversion=version_test/
+            end
+
+            it 'should pass no packaging' do
+              should_not match /-Dpackaging=/
+            end
+
+            it 'should pass no classifier' do
+              should_not match /-Dclassifier=/
+            end
+
+            context 'and a classifier' do
+              let(:params) do
+                {
+                  groupid: 'groupid_test',
+                  artifactid: 'artifactid_test',
+                  version: 'version_test',
+                  classifier: 'classifier_test'
+                }
+              end
+
+              it 'should pass the provided classifier' do
+                should match /-Dclassifier=classifier_test/
+              end
+            end
+
+            context 'and a packaging' do
+              let(:params) do
+                {
+                  groupid: 'groupid_test',
+                  artifactid: 'artifactid_test',
+                  version: 'version_test',
+                  packaging: 'packaging_test'
+                }
+              end
+
+              it 'should pass the provided packaging' do
+                should match /-Dpackaging=packaging_test/
+              end
+            end
+          end
+
+          context 'and an id' do
+            let(:params) { { id: 'artifact_test' } }
+
+            it 'should pass the provided id' do
+              should match /-Dartifact=artifact_test/
+            end
+
+            it 'should pass no groupid' do
+              should_not match /-DgroupId=/
+            end
+
+            it 'should pass no artifactid' do
+              should_not match /-DartifactId=/
+            end
+
+            it 'should pass no version' do
+              should_not match /-Dversion=/
+            end
+
+            it 'should not pass -U' do
+              should_not match /-U/
+            end
+          end
+
+          context 'and an id with a SNAPSHOT version' do
+            let(:params) { { id: 'groupid:artifactid:1.2.3-SNAPSHOT' } }
+
+            it 'should not pass -U' do
+              should_not match /-U/
+            end
+          end
+
+          context 'and a repoid' do
+            let(:params) { { repoid: 'repoid_test' } }
+
+            it 'should pass the provided repoid' do
+              should match /-DrepoId=repoid_test/
+            end
+          end
+
+          context 'and an explicit pluginversion' do
+            let(:params) { { pluginversion: '2.5' } }
+
+            it 'should pass provided version' do
+              should match /mvn org\.apache\.maven\.plugins:maven-dependency-plugin:2\.5:get/
+            end
+          end
+
+          context 'and an empty repo list' do
+            let(:params) { { repos: [] } }
+
+            it 'should default to http://repos1.maven.apache.org/maven2' do
+              should match /-DremoteRepositories=http:\/\/repo1.maven.apache.org\/maven2/
+            end
+          end
+
+          context 'and a repo list' do
+            let(:params) { { repos: ['http://repo1.com', 'http://repo2.com'] } }
+
+            it 'should pass the provided repos' do
+              should match /-DremoteRepositories=http:\/\/repo1.com,http:\/\/repo2.com/
+            end
+          end
+
+          context 'and a repo string' do
+            let(:params) { { repos: 'http://repo1.com' } }
+
+            it 'should pass the provided repos' do
+              should match /-DremoteRepositories=http:\/\/repo1.com/
+            end
+          end
+        end
+
+
+        context 'given a timeout' do
+          let(:params) { { timeout: 1 } }
+
+          it 'should use the given timeout' do
+            expect(Timeout).to receive(:timeout).with(1).and_call_original
+            expect(Puppet::Util::SUIDManager).to receive(:run_and_capture).and_return [nil, exitstatus]
+
+            subject
+          end
+
+          it 'should timeout if mvn takes too long' do
+            expect(Puppet::Util::SUIDManager).to receive(:run_and_capture) do 
+              sleep 2
+            end
+
+            expect { subject }.to raise_error Puppet::Error, /^Command timed out/
+          end
+        end
+
+        context 'given a user' do
+          let(:params) { { user: 'user_test' } }
+
+          it 'should use the given user' do
+            expect(Puppet::Util::SUIDManager).to receive(:run_and_capture)
+              .with(anything(), 'user_test', anything())
+              .and_return [nil, exitstatus]
+
+            subject
+          end
+        end
+
+        context 'given a group' do
+          let(:params) { { group: 'group_test' } }
+
+          it 'should use the given group' do
+            expect(Puppet::Util::SUIDManager).to receive(:run_and_capture)
+              .with(anything(), anything(), 'group_test')
+              .and_return [nil, exitstatus]
+
+            subject
+          end
+        end
+      end
+    end
+  end
+end

--- a/modules/maven/spec/unit/puppet/type/maven_spec.rb
+++ b/modules/maven/spec/unit/puppet/type/maven_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+type = Puppet::Type.type(:maven)
+
+describe type do
+  subject { type.new({name: name}.merge params)}
+  let(:params) { { } }
+
+  let(:name) { 'test' }
+
+  context 'given a valid id' do
+    let(:params) { {id: 'test_id'}.merge extra_params }
+    let(:extra_params) { { } }
+
+    example do
+      expect { subject }.to_not raise_error
+    end
+
+    context 'and an artifactid' do
+      let(:extra_params) { { artifactid: 'artifactid_test' } }
+
+      example do
+        expect { subject }.to raise_error Puppet::Error, /Can't define id and other groupid, artifactid, version, packaging, classifier parameters at the same time/
+      end
+    end
+
+    context 'and a groupid' do
+      let(:extra_params) { { groupid: 'groupid_test' } }
+
+      example do
+        expect { subject }.to raise_error Puppet::Error, /Can't define id and other groupid, artifactid, version, packaging, classifier parameters at the same time/
+      end
+    end
+
+    context 'and a version' do
+      let(:extra_params) { { version: 'version_test' } }
+
+      example do
+        expect { subject }.to raise_error Puppet::Error, /Can't define id and other groupid, artifactid, version, packaging, classifier parameters at the same time/
+      end
+    end
+
+    context 'and a packaging' do
+      let(:extra_params) { { packaging: 'packaging_test' } }
+
+      example do
+        expect { subject }.to raise_error Puppet::Error, /Can't define id and other groupid, artifactid, version, packaging, classifier parameters at the same time/
+      end
+    end
+
+    context 'and a packaging' do
+      let(:extra_params) { { classifier: 'classifier_test' } }
+
+      example do
+        expect { subject }.to raise_error Puppet::Error, /Can't define id and other groupid, artifactid, version, packaging, classifier parameters at the same time/
+      end
+    end
+  end
+
+  context 'given only an artifactid' do
+    let(:params) { { artifactid: 'artifactid_test' } }
+    example do
+      expect { subject }.to raise_error Puppet::Error, /Missing required groupid, artifactid or version parameters/
+    end
+  end
+
+  context 'given only a groupid' do
+    let(:params) { { groupid: 'groupid_test' } }
+    example do
+      expect { subject }.to raise_error Puppet::Error, /Missing required groupid, artifactid or version parameters/
+    end
+  end
+
+  context 'given only a version' do
+    let(:params) { { version: 'version_test' } }
+    example do
+      expect { subject }.to raise_error Puppet::Error, /Missing required groupid, artifactid or version parameters/
+    end
+  end
+
+  context 'given an artifactid, groupid, and version' do
+    let(:params) do
+      {
+        artifactid: 'artifactid_test',
+        groupid: 'groupid_test',
+        version: 'version_test',
+      }
+    end
+
+    example do
+      expect { subject }.to_not raise_error
+    end
+
+  end
+end
+
+

--- a/modules/maven/templates/mavenrc.erb
+++ b/modules/maven/templates/mavenrc.erb
@@ -1,0 +1,9 @@
+<% if has_variable?("maven_opts") and @maven_opts != "" -%>
+export MAVEN_OPTS="<%= @maven_opts %> $MAVEN_OPTS"
+<% end -%>
+<% if has_variable?("maven_path_additions") && @maven_path_additions != "" -%>
+export PATH="<%= @maven_path_additions %>:$PATH"
+<% end -%>
+<% if has_variable?("mavenrc_additions") && @mavenrc_additions != "" -%>
+<%= @mavenrc_additions %>
+<% end -%>

--- a/modules/maven/templates/settings.xml.erb
+++ b/modules/maven/templates/settings.xml.erb
@@ -1,0 +1,146 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+<%- unless @local_repo.empty? -%>
+  <localRepository><%= @local_repo %></localRepository>
+
+<%- end -%>
+<% unless @mirrors.empty? -%>
+  <mirrors>
+<% @mirrors.each do |mirror| -%>
+    <mirror>
+      <id><%= mirror['id'] %></id>
+      <url><%= mirror['url'] %></url>
+      <mirrorOf><%= mirror['mirrorof'] %></mirrorOf>
+    </mirror>
+<% end -%>
+  </mirrors>
+
+<% end -%>
+<% unless @servers.empty? -%>
+  <servers>
+<% @servers.each do |server| -%>
+    <server>
+      <id><%= server['id'] %></id>
+      <username><%= server['username'] %></username>
+      <password><%= server['password'] %></password>
+    </server>
+<% end -%>
+  </servers>
+
+<% end -%>
+<% unless @proxies.empty? -%>
+  <proxies>
+<% @proxies.each do |proxy| -%>
+    <proxy>
+<% if(proxy['active'].nil?) -%>
+      <active>true</active>
+<% else -%>
+      <active><%= proxy['active'] %></active>
+<% end -%>
+<% if(proxy['protocol'].nil?) -%>
+      <protocol>http</protocol>
+<% else -%>
+      <protocol><%= proxy['protocol'] %></protocol>
+<% end -%>
+      <host><%= proxy['host'] %></host>
+<% unless(proxy['port'].nil?) -%>
+      <port><%= proxy['port'] %></port>
+<% end -%>
+<% unless(proxy['username'].nil?) -%>
+      <username><%= proxy['username'] %></username>
+<% end -%>
+<% unless(proxy['password'].nil?) -%>
+      <password><%= proxy['password'] %></password>
+<% end -%>
+<% unless(proxy['nonProxyHosts'].nil?) -%>
+      <nonProxyHosts><%= proxy['nonProxyHosts'] %></nonProxyHosts>
+<% end -%>
+    </proxy>
+<% end -%>
+  </proxies>
+
+<% end -%>
+<% 
+  unless @default_repo_config.nil? or @default_repo_config.empty?
+    @default_repo_config['id'] = 'central'
+    @repos << @default_repo_config
+  end
+-%>
+<% unless @repos.empty? and @properties.empty? -%>
+  <profiles>
+    <%- unless @repos.empty? -%>
+    <profile>
+      <id>default-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+<% @repos.each do |repo| -%>
+        <repository>
+          <id><%= repo['id'] %></id>
+<% unless repo['name'].nil? -%>
+          <name><%= repo['name'] %></name>
+<% end -%>
+          <url><%= repo['url'] %></url>
+          <%- unless repo['snapshots'].nil? or repo['snapshots'].empty? -%>
+          <snapshots>
+            <%- repo['snapshots'].sort.each { |key,value| -%>
+            <%=  "<#{key}>#{value}</#{key}>" %>
+            <%- } -%>
+          </snapshots>
+          <%- end -%>
+          <%- unless repo['releases'].nil? or repo['releases'].empty? -%>
+          <releases>
+            <%- repo['releases'].sort.each { |key,value| -%>
+            <%=  "<#{key}>#{value}</#{key}>" %>
+            <%- } -%>
+          </releases>
+          <%- end -%>
+        </repository>
+<% end -%>
+      </repositories>
+      <pluginRepositories>
+<% @repos.each do |repo| -%>
+        <pluginRepository>
+          <id><%= repo['id'] %></id>
+<% unless repo['name'].nil? -%>
+          <name><%= repo['name'] %></name>
+<% end -%>
+          <url><%= repo['url'] %></url>
+          <%- unless repo['snapshots'].nil? or repo['snapshots'].empty? -%>
+          <snapshots>
+            <%- repo['snapshots'].sort.each { |key,value| -%>
+            <%=  "<#{key}>#{value}</#{key}>" %>
+            <%- } -%>
+          </snapshots>
+          <%- end -%>
+          <%- unless repo['releases'].nil? or repo['releases'].empty? -%>
+          <releases>
+            <%- repo['releases'].sort.each { |key,value| -%>
+            <%=  "<#{key}>#{value}</#{key}>" %>
+            <%- } -%>
+          </releases>
+          <%- end -%>
+        </pluginRepository>
+<% end -%>
+      </pluginRepositories>
+    </profile>
+    <%- end -%>
+    <%- unless @properties.empty? -%>
+    <profile>
+      <id>properties</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <%- @properties.sort.each { |key, value| -%>
+        <%=  "<#{key}>#{value}</#{key}>" %>
+        <%- } -%>
+      </properties>
+    </profile>
+    <%- end -%>
+  </profiles>
+
+<% end -%>
+</settings>

--- a/modules/maven/tests/init.pp
+++ b/modules/maven/tests/init.pp
@@ -1,0 +1,25 @@
+class { 'java': }
+
+$repo1 = {
+  id       => 'myrepo',
+  username => 'myuser',
+  password => 'mypassword',
+  url      => 'http://repo.acme.com',
+}
+
+class { 'maven::maven': } ->
+
+#maven::settings { 'root' :
+#  servers => [$repo1],
+#}
+
+maven { '/tmp/maven-core-3.0.5.jar':
+  id     => 'org.apache.maven:maven-core:3.0.5:jar',
+  repos  => ['central::default::http://repo1.maven.apache.org/maven2','http://mirrors.ibiblio.org/pub/mirrors/maven2'],
+} ->
+maven { '/tmp/maven-core-3.0.5-sources.jar':
+  groupid    => 'org.apache.maven',
+  artifactid => 'maven-core',
+  version    => '3.0.5',
+  classifier => 'sources',
+}

--- a/modules/rpmbuilder/manifests/init.pp
+++ b/modules/rpmbuilder/manifests/init.pp
@@ -3,7 +3,7 @@
 class rpmbuilder {
   include maven
 
-  $linux_packages = ['wget', 'curl', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel']
+  $linux_packages = ['wget', 'curl', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel', 'createrepo']
   $java_packages = ['jakarta-commons-collections', 'tomcat6', 'java-1.6.0-openjdk-devel'] 
 
   package { $linux_packages:

--- a/modules/rpmbuilder/manifests/init.pp
+++ b/modules/rpmbuilder/manifests/init.pp
@@ -17,6 +17,13 @@ class rpmbuilder {
     home   => '/var/lib/jenkins',
   }
 
+  file { '/var/lib/jenkins':
+    ensure => directory,
+    owner  => 'jenkins',
+    group  => 'jenkins',
+    mode   => 755,
+  }
+
   package { $linux_packages:
     ensure => installed,
   }

--- a/modules/rpmbuilder/manifests/init.pp
+++ b/modules/rpmbuilder/manifests/init.pp
@@ -5,10 +5,13 @@ class rpmbuilder {
 
   $linux_packages = ['wget', 'curl', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel']
   $java_packages = ['jakarta-commons-collections', 'tomcat', 'java-1.6.0-openjdk-devel'] 
-  package { $packages: 
+
+  package { $linux_packages:
+    ensure => installed,
+  }
+  package { $java_packages: 
       ensure => installed,
   }
-
   #Needed for systemvm.iso
   package { 'genisoimage':
     ensure => installed,

--- a/modules/rpmbuilder/manifests/init.pp
+++ b/modules/rpmbuilder/manifests/init.pp
@@ -1,0 +1,27 @@
+#rpmbuilder - build tools mvn, java, createrepo, yum
+
+class rpmbuilder {
+  include maven
+
+  $linux_packages = ['wget', 'curl', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel']
+  $java_packages = ['jakarta-commons-collections', 'tomcat', 'java-1.6.0-openjdk-devel'] 
+  package { $packages: 
+      ensure => installed,
+  }
+
+  #Needed for systemvm.iso
+  package { 'genisoimage':
+    ensure => installed,
+  }
+
+  case $operatingsystem {
+    centos,redhat : {
+    }
+    fedora : {
+    }
+  }
+
+  service { 'mysqld':
+    ensure => running,
+  }
+}

--- a/modules/rpmbuilder/manifests/init.pp
+++ b/modules/rpmbuilder/manifests/init.pp
@@ -4,7 +4,8 @@ class rpmbuilder {
   include maven
 
   $linux_packages = ['wget', 'curl', 'git', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel', 'createrepo', 'rpm-build']
-  $java_packages = ['jakarta-commons-collections', 'tomcat6', 'java-1.6.0-openjdk-devel'] 
+  $java_packages = ['jakarta-commons-collections', 'tomcat6', 'java-1.6.0-openjdk-devel', 'ws-commons-util'] 
+  $python_packages = ['MySQL-python', 'python-pip']
 
   group { 'jenkins':
     ensure => present,
@@ -20,7 +21,10 @@ class rpmbuilder {
     ensure => installed,
   }
   package { $java_packages: 
-  ensure => installed,
+    ensure => installed,
+  }
+  package { $python_packages: 
+    ensure => installed,
   }
   #Needed for systemvm.iso
   package { 'genisoimage':

--- a/modules/rpmbuilder/manifests/init.pp
+++ b/modules/rpmbuilder/manifests/init.pp
@@ -3,14 +3,24 @@
 class rpmbuilder {
   include maven
 
-  $linux_packages = ['wget', 'curl', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel', 'createrepo']
+  $linux_packages = ['wget', 'curl', 'git', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel', 'createrepo', 'rpm-build']
   $java_packages = ['jakarta-commons-collections', 'tomcat6', 'java-1.6.0-openjdk-devel'] 
+
+  group { 'jenkins':
+    ensure => present,
+  }
+
+  user { 'jenkins':
+    ensure => present,
+    groups => ['jenkins'],
+    home   => '/var/lib/jenkins',
+  }
 
   package { $linux_packages:
     ensure => installed,
   }
   package { $java_packages: 
-      ensure => installed,
+  ensure => installed,
   }
   #Needed for systemvm.iso
   package { 'genisoimage':

--- a/modules/rpmbuilder/manifests/init.pp
+++ b/modules/rpmbuilder/manifests/init.pp
@@ -4,7 +4,7 @@ class rpmbuilder {
   include maven
 
   $linux_packages = ['wget', 'curl', 'openssh-clients', 'mysql-server', 'gcc', 'glibc-devel']
-  $java_packages = ['jakarta-commons-collections', 'tomcat', 'java-1.6.0-openjdk-devel'] 
+  $java_packages = ['jakarta-commons-collections', 'tomcat6', 'java-1.6.0-openjdk-devel'] 
 
   package { $linux_packages:
     ensure => installed,

--- a/modules/wget/Gemfile
+++ b/modules/wget/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+
+group :rake do
+  gem 'puppet',       '>=2.7.17'
+  gem 'rspec-puppet', '>=0.1.3'
+  gem 'rake',         '>=0.9.2.2'
+  gem 'puppet-lint',  '>=0.1.12'
+  gem 'puppetlabs_spec_helper'
+  gem 'puppet-blacksmith', '>=1.0.5'
+end

--- a/modules/wget/Gemfile.lock
+++ b/modules/wget/Gemfile.lock
@@ -1,0 +1,56 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.4)
+    facter (1.7.2)
+    hiera (1.2.1)
+      json_pure
+    json_pure (1.8.0)
+    metaclass (0.0.1)
+    mime-types (1.24)
+    mini_portile (0.5.1)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    nokogiri (1.6.0)
+      mini_portile (~> 0.5.0)
+    puppet (3.2.4)
+      facter (~> 1.6)
+      hiera (~> 1.0)
+      rgen (~> 0.6.5)
+    puppet-blacksmith (1.0.5)
+      nokogiri
+      puppet (>= 2.7.16)
+      puppetlabs_spec_helper (>= 0.3.0)
+      rake
+      rest-client
+    puppet-lint (0.3.2)
+    puppetlabs_spec_helper (0.4.1)
+      mocha (>= 0.10.5)
+      rake
+      rspec (>= 2.9.0)
+      rspec-puppet (>= 0.1.1)
+    rake (10.1.0)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
+    rgen (0.6.5)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.5)
+    rspec-expectations (2.14.2)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.3)
+    rspec-puppet (0.1.6)
+      rspec
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  puppet (>= 2.7.17)
+  puppet-blacksmith (>= 1.0.5)
+  puppet-lint (>= 0.1.12)
+  puppetlabs_spec_helper
+  rake (>= 0.9.2.2)
+  rspec-puppet (>= 0.1.3)

--- a/modules/wget/Modulefile
+++ b/modules/wget/Modulefile
@@ -1,0 +1,8 @@
+name    'maestrodev-wget'
+version '1.2.2'
+source 'http://github.com/maestrodev/puppet-wget.git'
+author 'maestrodev'
+license 'Apache License, Version 2.0'
+summary 'Download files with wget'
+description 'A module for wget that allows downloading of files, supporting authentication'
+project_page 'http://github.com/maestrodev/puppet-wget'

--- a/modules/wget/README.md
+++ b/modules/wget/README.md
@@ -1,0 +1,55 @@
+A Puppet module to download files with wget, supporting authentication.
+
+# Example
+
+install wget:
+
+```puppet
+	   include wget
+```
+	
+```puppet
+	   wget::fetch { "download Google's index":
+       source      => 'http://www.google.com/index.html',
+       destination => '/tmp/index.html',
+       timeout     => 0,
+       verbose     => false,
+	}
+```
+or alternatively: 
+
+```puppet
+     wget::fetch { 'http://www.google.com/index.html':
+       destination => '/tmp/index.html',
+       timeout     => 0,
+       verbose     => false,
+     }
+```
+This fetches a document which requires authentication:
+
+```puppet
+     wget::authfetch { 'Fetch secret PDF':
+        source      => 'https://confidential.example.com/secret.pdf',
+        destination => '/tmp/secret.pdf',
+        user        => 'user',
+        password    => 'p$ssw0rd',
+        timeout     => 0,
+        verbose     => false,
+     }
+```
+
+# License
+
+Copyright 2011-2013 MaestroDev
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/modules/wget/Rakefile
+++ b/modules/wget/Rakefile
@@ -1,0 +1,13 @@
+require 'bundler'
+Bundler.require(:rake)
+require 'rake/clean'
+
+CLEAN.include('spec/fixtures/', 'doc', 'pkg')
+CLOBBER.include('.tmp', '.librarian')
+
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet_blacksmith/rake_tasks'
+
+PuppetLint.configuration.send("disable_80chars")
+
+task :default => [:clean, :spec]

--- a/modules/wget/manifests/authfetch.pp
+++ b/modules/wget/manifests/authfetch.pp
@@ -1,0 +1,72 @@
+################################################################################
+# Definition: wget::authfetch
+#
+# This class will download files from the internet.  You may define a web proxy
+# using $::http_proxy if necessary. Username must be provided. And the user's
+# password must be stored in the password variable within the .wgetrc file.
+#
+################################################################################
+define wget::authfetch (
+  $destination,
+  $user,
+  $source             = $title,
+  $password           = '',
+  $timeout            = '0',
+  $verbose            = false,
+  $redownload         = false,
+  $nocheckcertificate = false,
+  $execuser           = 'root',
+) {
+
+  include wget
+
+  if $::http_proxy {
+    $environment = [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}", "WGETRC=/tmp/wgetrc-${name}" ]
+  }
+  else {
+    $environment = [ "WGETRC=/tmp/wgetrc-${name}" ]
+  }
+
+  $verbose_option = $verbose ? {
+    true  => '--verbose',
+    false => '--no-verbose'
+  }
+
+  $unless_test = $redownload ? {
+    true  => 'test',
+    false => "test -s ${destination}"
+  }
+
+  $nocheckcert_option = $nocheckcertificate ? {
+    true  => ' --no-check-certificate',
+    false => ''
+  }
+
+  case $::operatingsystem {
+    'Darwin': {
+      # This is to work around an issue with macports wget and out of date CA cert bundle.  This requires
+      # installing the curl-ca-bundle package like so:
+      #
+      # sudo port install curl-ca-bundle
+      $wgetrc_content = "password=${password}\nCA_CERTIFICATE=/opt/local/share/curl/curl-ca-bundle.crt\n"
+    }
+    default: {
+      $wgetrc_content = "password=${password}"
+    }
+  }
+
+  file { "/tmp/wgetrc-${name}":
+    owner   => 'root',
+    mode    => '0600',
+    content => $wgetrc_content,
+  } ->
+  exec { "wget-${name}":
+    command     => "wget ${verbose_option}${nocheckcert_option} --user=${user} --output-document='${destination}' '${source}'",
+    timeout     => $timeout,
+    unless      => $unless_test,
+    environment => $environment,
+    user        => $execuser,
+    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
+    require     => Class['wget'],
+  }
+}

--- a/modules/wget/manifests/fetch.pp
+++ b/modules/wget/manifests/fetch.pp
@@ -1,0 +1,54 @@
+################################################################################
+# Definition: wget::fetch
+#
+# This class will download files from the internet.  You may define a web proxy
+# using $http_proxy if necessary.
+#
+################################################################################
+define wget::fetch (
+  $destination,
+  $source             = $title,
+  $timeout            = '0',
+  $verbose            = false,
+  $redownload         = false,
+  $nocheckcertificate = false,
+  $execuser           = 'root',
+) {
+
+  include wget
+
+  # using "unless" with test instead of "creates" to re-attempt download
+  # on empty files.
+  # wget creates an empty file when a download fails, and then it wouldn't try
+  # again to download the file
+  if $::http_proxy {
+    $environment = [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ]
+  } else {
+    $environment = []
+  }
+
+  $verbose_option = $verbose ? {
+    true  => '--verbose',
+    false => '--no-verbose'
+  }
+
+  $unless_test = $redownload ? {
+    true  => 'test',
+    false => "test -s ${destination}"
+  }
+
+  $nocheckcert_option = $nocheckcertificate ? {
+    true  => ' --no-check-certificate',
+    false => ''
+  }
+
+  exec { "wget-${name}":
+    command     => "wget ${verbose_option}${nocheckcert_option} --output-document='${destination}' '${source}'",
+    timeout     => $timeout,
+    unless      => $unless_test,
+    environment => $environment,
+    user        => $execuser,
+    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
+    require     => Class['wget'],
+  }
+}

--- a/modules/wget/manifests/init.pp
+++ b/modules/wget/manifests/init.pp
@@ -1,0 +1,16 @@
+################################################################################
+# Class: wget
+#
+# This class will install wget - a tool used to download content from the web.
+#
+################################################################################
+class wget (
+  $version = present,
+) {
+
+  if $::operatingsystem != 'Darwin' {
+    if ! defined(Package['wget']) {
+      package { 'wget': ensure => $version }
+    }
+  }
+}

--- a/modules/wget/metadata.json
+++ b/modules/wget/metadata.json
@@ -1,0 +1,30 @@
+{
+  "name": "maestrodev-wget",
+  "version": "1.2.2",
+  "source": "http://github.com/maestrodev/puppet-wget.git",
+  "author": "maestrodev",
+  "license": "Apache License, Version 2.0",
+  "summary": "Download files with wget",
+  "description": "A module for wget that allows downloading of files, supporting authentication",
+  "project_page": "http://github.com/maestrodev/puppet-wget",
+  "dependencies": [
+
+  ],
+  "types": [
+
+  ],
+  "checksums": {
+    "Gemfile": "e5baf638115a41d73cb299daf9ad9502",
+    "Gemfile.lock": "a19a873ba6ef14190e91851332d79f4c",
+    "Modulefile": "68e4ce1c27fec65fa5feb82141a3f51e",
+    "README.md": "5ce4d709d50ff635f78b7580fa291142",
+    "Rakefile": "31adafa1c0ed7d932985b6d1af89ecff",
+    "manifests/authfetch.pp": "8fe8e554f4d99777e5ad242ff84ccf3e",
+    "manifests/fetch.pp": "617d2950b21b86d8e5212b325a778f67",
+    "manifests/init.pp": "582c44cad08f204e424fc361327842b7",
+    "spec/classes/init_spec.rb": "154db01e3fff4f58689fc8729ec1a721",
+    "spec/defines/authfetch_spec.rb": "b6876f4b3319410f11c11d3a985c210b",
+    "spec/defines/fetch_spec.rb": "68133dec0512ea777afa581f763c79a1",
+    "spec/spec_helper.rb": "0db89c9a486df193c0e40095422e19dc"
+  }
+}

--- a/modules/wget/spec/classes/init_spec.rb
+++ b/modules/wget/spec/classes/init_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'wget' do
+
+  context 'running on OS X' do
+    let(:facts) { {:operatingsystem => 'Darwin'} }
+
+    it { should_not contain_package('wget') }
+  end
+
+  context 'running on CentOS' do
+    let(:facts) { {:operatingsystem => 'CentOS'} }
+
+    it { should contain_package('wget') }
+  end
+
+  context 'no version specified' do
+    it { should contain_package('wget').with_ensure('present') }
+  end
+
+  context 'version is 1.2.3' do
+    let(:params) { {:version => '1.2.3'} }
+
+    it { should contain_package('wget').with_ensure('1.2.3') }
+  end
+end

--- a/modules/wget/spec/defines/authfetch_spec.rb
+++ b/modules/wget/spec/defines/authfetch_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'wget::authfetch' do
+  let(:title) { 'authtest' }
+  let(:params) {{
+    :source      => 'http://localhost/source',
+    :destination => '/tmp/dest',
+    :user        => 'myuser',
+    :password    => 'mypassword',
+  }}
+
+  context "with default params" do
+    it { should contain_exec('wget-authtest').with({
+      'command'     => "wget --no-verbose --user=myuser --output-document='/tmp/dest' 'http://localhost/source'",
+      'environment' => 'WGETRC=/tmp/wgetrc-authtest'
+      })
+    }
+    it { should contain_file('/tmp/wgetrc-authtest').with_content('password=mypassword') }
+  end
+
+  context "with user" do
+    let(:params) { super().merge({
+      :execuser => 'testuser',
+    })}
+
+    it { should contain_exec('wget-authtest').with({
+      'command' => "wget --no-verbose --user=myuser --output-document='/tmp/dest' 'http://localhost/source'",
+      'user'    => 'testuser'
+    }) }
+  end
+end

--- a/modules/wget/spec/defines/fetch_spec.rb
+++ b/modules/wget/spec/defines/fetch_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'wget::fetch' do
+  let(:title) { 'test' }
+
+  let(:params) {{
+    :source      => 'http://localhost/source',
+    :destination => '/tmp/dest',
+  }}
+
+  context "with default params" do
+    it { should contain_exec('wget-test').with_command("wget --no-verbose --output-document='/tmp/dest' 'http://localhost/source'") }
+  end
+
+  context "with user" do
+    let(:params) { super().merge({
+      :execuser => 'testuser',
+    })}
+
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --output-document='/tmp/dest' 'http://localhost/source'",
+      'user'    => 'testuser'
+    }) }
+  end
+end

--- a/modules/wget/spec/spec_helper.rb
+++ b/modules/wget/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
rpmbuilder slaves are build environments for building and packaging cloudstack code. Such slaves will contain packages essential to generate cloudstack builds.

Apply the manifest using

On masterless
$ puppet apply --modulepath ./modules manifest/site.pp
